### PR TITLE
ci: adds coodespell and shellcheck to github

### DIFF
--- a/.github/workflows/odf-must-gather-ci.yaml
+++ b/.github/workflows/odf-must-gather-ci.yaml
@@ -1,0 +1,35 @@
+---
+name: odf-must-gather sanity checks
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+  
+  code-spell:
+    name: verify code spellings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          check_hidden: true
+          ignore_words_list: xdescribe,contails,shouldnot
+


### PR DESCRIPTION
This commit adds basic codespell and shellcheck
to ci.

Signed-off-by: yati1998 <ypadia@redhat.com>