### PR TITLE
Gather: Use utility function to append to debug logs

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -6,7 +6,7 @@ mkdir -p ${BASE_COLLECTION_PATH}
 SINCE_TIME=$1
 
 # Source the utils
-# shellcheck source=utils.sh
+# shellcheck disable=SC1091
 . utils.sh
 
 # timestamp for starting of the script

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -5,13 +5,16 @@ mkdir -p ${BASE_COLLECTION_PATH}
 # Command line argument
 SINCE_TIME=$1
 
+# Source the utils
+. utils.sh
+
 # timestamp for starting of the script
 START_TIME=$(date +%r)
 start=$(date +%s)
-printf "collection started at: %s \n" "${START_TIME}" >> ${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
+dbglog "collection started at: ${START_TIME}"
 
-# Call pre-install.sh
-pre-install.sh
+# Call pre-install.sh, see commit msg
+pre-install.sh ${BASE_COLLECTION_PATH}
 
 # Call other gather scripts
 gather_namespaced_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
@@ -24,14 +27,14 @@ externalStorageClusterPresent=$(oc get storagecluster -n "${namespace}" -o go-te
 reconcileStrategy=$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
 
 if [ "${externalStorageClusterPresent}" == true ]; then
-    echo "Collecting limited ceph logs since external cluster is present" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    dbglog "Collecting limited ceph logs since external cluster is present"
     gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
 elif [ -z "${storageClusterPresent}" ]; then
-    echo "Skipping ceph collection as Storage Cluster is not present" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    dbglog "Skipping ceph collection as Storage Cluster is not present"
 elif [ "${reconcileStrategy}" = "standalone" ]; then
-    echo "Skipping ceph collection as this is a MCG only cluster" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    dbglog "Skipping ceph collection as this is a MCG only cluster"
 else
-    echo "Collecting entire ceph logs" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+    dbglog "Collecting entire ceph logs"
     gather_ceph_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 fi
 
@@ -41,12 +44,12 @@ post-uninstall.sh
 # timestamp for ending of the script
 END_TIME=$(date +%r)
 end=$(date +%s)
-totalTime=$((end-start))
+totalTime=$((end - start))
 {
     printf "total time taken by collection was %s seconds \n" ${totalTime}
     printf "collection ended at: %s \n" "${END_TIME}"
     echo "deleting empty files"
 
-} >> ${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
-find "${BASE_COLLECTION_PATH}" -empty -delete >> ${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
+} >>${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
+find "${BASE_COLLECTION_PATH}" -empty -delete >>${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
 exit 0

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -6,6 +6,7 @@ mkdir -p ${BASE_COLLECTION_PATH}
 SINCE_TIME=$1
 
 # Source the utils
+# shellcheck source=utils.sh
 . utils.sh
 
 # timestamp for starting of the script

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -6,9 +6,6 @@ BASE_COLLECTION_PATH=$1
 # Expect time option as an argument
 SINCE_TIME=$2
 
-# Source the utils
-. utils.sh
-
 gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
 
 # Use PWD as base path if no argument is passed

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -13,6 +13,7 @@ if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
 
+CEPH_GATHER_DBGLOG="${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
 CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
 
 # Ceph resources
@@ -115,7 +116,7 @@ for ns in $namespaces; do
 
         # Collecting output of ceph commands
         for ((i = 0; i < ${#ceph_commands[@]}; i++)); do
-            printf "collecting command output for: %s\n" "${ceph_commands[$i]}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            printf "collecting command output for: %s\n" "${ceph_commands[$i]}" | tee -a "${CEPH_GATHER_DBGLOG}"
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_commands[$i]// /_}
             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_commands[$i]// /_}_--format_json-pretty
             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_commands[$i]}"-debug.log 2>&1 &
@@ -126,7 +127,7 @@ for ns in $namespaces; do
             # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
             # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
             while [ "$(ps aux | wc -l)" -gt 100 ]; do
-                printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${CEPH_GATHER_DBGLOG}"
                 sleep 2
             done
         done
@@ -136,13 +137,13 @@ for ns in $namespaces; do
         done
 
         # Collecting output for ceph subvolume output
-        printf "collecting output for cephFS filesystem\n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting output for cephFS filesystem\n" | tee -a "${CEPH_GATHER_DBGLOG}"
         # Inspecting CephFS filesystems
         filesystems=$(timeout 60 oc get cephfilesystems.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
 
         for fs in $filesystems; do
             ceph_command="ceph fs subvolumegroup ls ${fs}"
-            printf "collecting command output for: %s\n" "${ceph_command}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            printf "collecting command output for: %s\n" "${ceph_command}" | tee -a "${CEPH_GATHER_DBGLOG}"
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_command// /_}
             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_command// /_}_--format_json-pretty
             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_command}"-debug.log 2>&1 &
@@ -152,7 +153,7 @@ for ns in $namespaces; do
             subvolgrp_name=$(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command}" | awk -F\" '{print $4}')
             for svg in $subvolgrp_name; do
                 subvolume_command="ceph fs subvolume ls ${fs} ${svg}"
-                printf "collecting command output for: %s\n" "${subvolume_command}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                printf "collecting command output for: %s\n" "${subvolume_command}" | tee -a "${CEPH_GATHER_DBGLOG}"
                 COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${subvolume_command// /_}
                 JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${subvolume_command// /_}_--format_json-pretty
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${subvolume_command} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${subvolume_command}"-debug.log 2>&1 &
@@ -164,7 +165,7 @@ for ns in $namespaces; do
 
         # Collecting output of rados commands
         for ((i = 0; i < ${#rados_commands[@]}; i++)); do
-            printf "collecting command output for: %s\n" "${rados_commands[$i]}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            printf "collecting command output for: %s\n" "${rados_commands[$i]}" | tee -a "${CEPH_GATHER_DBGLOG}"
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${rados_commands[$i]// /_}
             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${rados_commands[$i]} " >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${rados_commands[$i]}"-debug.log 2>&1 &
             pids_ceph+=($!)
@@ -173,7 +174,7 @@ for ns in $namespaces; do
         # Collecting rados object information for CephFS PVs and snapshots
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rados_cephfs_objects
         # List filesystem and Get the metadata pool name of the filesystem
-        printf "Collecting metadata pool name of the filesystem \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "Collecting metadata pool name of the filesystem \n" | tee -a "${CEPH_GATHER_DBGLOG}"
         mdpools=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs ls --format=json | jq '.[] | .metadata_pool'")
         for mdpool in $mdpools; do
             { printf "Name of the metadata pool: %s\n" "${mdpool}" >>"${COMMAND_OUTPUT_FILE}"; }
@@ -236,7 +237,7 @@ for ns in $namespaces; do
         done
 
         # collecting trash list for ceph rbd
-        printf "collecting trash list for ceph rbd \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting trash list for ceph rbd \n" | tee -a "${CEPH_GATHER_DBGLOG}"
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
         for bp in $blockpools; do
@@ -245,7 +246,7 @@ for ns in $namespaces; do
         done
 
         # Collecting snapshot info for ceph rbd volumes
-        printf "collecting snapshot info for ceph rbd volumes \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting snapshot info for ceph rbd volumes \n" | tee -a "${CEPH_GATHER_DBGLOG}"
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_vol_and_snap_info
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
@@ -254,7 +255,7 @@ for ns in $namespaces; do
             images=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
             pids_rbd=()
             for image in $images; do
-                printf "collecting vol and snapshot info for %s\n" "${image}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                printf "collecting vol and snapshot info for %s\n" "${image}" | tee -a "${CEPH_GATHER_DBGLOG}"
                 {
                     printf "Collecting image info for: %s/%s\n" "${bp}" "${image}"
                     timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log
@@ -276,13 +277,13 @@ for ns in $namespaces; do
         # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
         # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
         while [ "$(ps aux | wc -l)" -gt 100 ]; do
-            printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${CEPH_GATHER_DBGLOG}"
             sleep 2
         done
         # Collecting rbd mirroring info for ceph rbd volumes
-        printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a "${CEPH_GATHER_DBGLOG}"
         # Checking snapshot schedule status and list
-        printf "collecting snapshot schedule status and list \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting snapshot schedule status and list \n" | tee -a "${CEPH_GATHER_DBGLOG}"
         { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule status --format=json --pretty-format" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_status; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-status-debug.log 2>&1 &
         pids_ceph+=($!)
         { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule ls --recursive --format=json --pretty-format" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_ls; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-debug.log 2>&1 &
@@ -294,7 +295,7 @@ for ns in $namespaces; do
             isEnabled=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json | jq --raw-output '.mode'")
             if [ "${isEnabled}" != "disabled" ]; then
                 pids_rbd=()
-                printf "Mirroring is enabled on: %s\n" "${bp}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                printf "Mirroring is enabled on: %s\n" "${bp}" | tee -a "${CEPH_GATHER_DBGLOG}"
                 {
                     printf "Collecting mirror pool status for: %s\n" "${bp}"
                     timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status --verbose $bp --format=json --pretty-format" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log
@@ -308,7 +309,7 @@ for ns in $namespaces; do
                 printf "Collecting mirror image status for images in: %s\n" "${bp}" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
                 images=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
                 for image in $images; do
-                    printf "Printing information for image: %s\n" "${image}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                    printf "Printing information for image: %s\n" "${image}" | tee -a "${CEPH_GATHER_DBGLOG}"
                     {
                         printf "Collecting mirror image status for: %s/%s\n" "${bp}" "${image}"
                         timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json --pretty-format" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log
@@ -330,7 +331,7 @@ for ns in $namespaces; do
         done
 
         # Collecting snapshot information for ceph subvolumes
-        printf "collecting snapshot info for cephFS subvolumes \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting snapshot info for cephFS subvolumes \n" | tee -a "${CEPH_GATHER_DBGLOG}"
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/cephfs_subvol_and_snap_info
 
         for fs in $filesystems; do
@@ -355,13 +356,13 @@ for ns in $namespaces; do
                 done
             done
         done
-        printf "waiting for pids to finish \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "waiting for pids to finish \n" | tee -a "${CEPH_GATHER_DBGLOG}"
         wait "${pids_ceph[@]}"
     }
     if [ "$(oc get pods --no-headers -n "${ns}" -l must-gather-helper-pod='' | awk '{print $2}')" == "1/1" ]; then
         ceph_collection
     else
-        echo "skipping the ceph collection" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        echo "skipping the ceph collection" | tee -a "${CEPH_GATHER_DBGLOG}"
     fi
     # Collecting output of ceph volume commands
     for ((i = 0; i < ${#ceph_volume_commands[@]}; i++)); do
@@ -449,5 +450,5 @@ CMDS
     echo "ceph core dump collection completed" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
 done
 
-cat "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
-rm -rf "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+cat "${CEPH_GATHER_DBGLOG}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+rm -rf "${CEPH_GATHER_DBGLOG}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -91,8 +91,8 @@ rados_commands+=("rados ls --pool=ocs-storagecluster-cephfilesystem-metadata --n
 
 # Inspecting ceph related custom resources for all namespaces
 for resource in "${ceph_resources[@]}"; do
-    echo "collecting dump ${resource}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
-    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    dbglog "collecting dump ${resource}"
+    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 done
 
 namespaces=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
@@ -116,7 +116,7 @@ for ns in $namespaces; do
 
         # Collecting output of ceph commands
         for ((i = 0; i < ${#ceph_commands[@]}; i++)); do
-            printf "collecting command output for: %s\n" "${ceph_commands[$i]}" | tee -a "${CEPH_GATHER_DBGLOG}"
+            dbglogf "${CEPH_GATHER_DBGLOG}" "collecting command output for: ${ceph_commands[$i]}"
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_commands[$i]// /_}
             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_commands[$i]// /_}_--format_json-pretty
             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_commands[$i]}"-debug.log 2>&1 &
@@ -127,7 +127,7 @@ for ns in $namespaces; do
             # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
             # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
             while [ "$(ps aux | wc -l)" -gt 100 ]; do
-                printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+                dbglogf "${CEPH_GATHER_DBGLOG}" "waiting for PIDs to be empty before proceeding"
                 sleep 2
             done
         done
@@ -137,13 +137,13 @@ for ns in $namespaces; do
         done
 
         # Collecting output for ceph subvolume output
-        printf "collecting output for cephFS filesystem\n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "collecting output for cephFS filesystem"
         # Inspecting CephFS filesystems
         filesystems=$(timeout 60 oc get cephfilesystems.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
 
         for fs in $filesystems; do
             ceph_command="ceph fs subvolumegroup ls ${fs}"
-            printf "collecting command output for: %s\n" "${ceph_command}" | tee -a "${CEPH_GATHER_DBGLOG}"
+            dbglogf "${CEPH_GATHER_DBGLOG}" "collecting command output for: ${ceph_command}"
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_command// /_}
             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_command// /_}_--format_json-pretty
             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_command}"-debug.log 2>&1 &
@@ -153,7 +153,7 @@ for ns in $namespaces; do
             subvolgrp_name=$(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command}" | awk -F\" '{print $4}')
             for svg in $subvolgrp_name; do
                 subvolume_command="ceph fs subvolume ls ${fs} ${svg}"
-                printf "collecting command output for: %s\n" "${subvolume_command}" | tee -a "${CEPH_GATHER_DBGLOG}"
+                dbglogf "${CEPH_GATHER_DBGLOG}" "collecting command output for: ${subvolume_command}"
                 COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${subvolume_command// /_}
                 JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${subvolume_command// /_}_--format_json-pretty
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${subvolume_command} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${subvolume_command}"-debug.log 2>&1 &
@@ -165,7 +165,7 @@ for ns in $namespaces; do
 
         # Collecting output of rados commands
         for ((i = 0; i < ${#rados_commands[@]}; i++)); do
-            printf "collecting command output for: %s\n" "${rados_commands[$i]}" | tee -a "${CEPH_GATHER_DBGLOG}"
+            dbglogf "${CEPH_GATHER_DBGLOG}" "collecting command output for: ${rados_commands[$i]}"
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${rados_commands[$i]// /_}
             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${rados_commands[$i]} " >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${rados_commands[$i]}"-debug.log 2>&1 &
             pids_ceph+=($!)
@@ -174,7 +174,7 @@ for ns in $namespaces; do
         # Collecting rados object information for CephFS PVs and snapshots
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rados_cephfs_objects
         # List filesystem and Get the metadata pool name of the filesystem
-        printf "Collecting metadata pool name of the filesystem \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "Collecting metadata pool name of the filesystem"
         mdpools=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs ls --format=json | jq '.[] | .metadata_pool'")
         for mdpool in $mdpools; do
             { printf "Name of the metadata pool: %s\n" "${mdpool}" >>"${COMMAND_OUTPUT_FILE}"; }
@@ -237,7 +237,7 @@ for ns in $namespaces; do
         done
 
         # collecting trash list for ceph rbd
-        printf "collecting trash list for ceph rbd \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "collecting trash list for ceph rbd"
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
         for bp in $blockpools; do
@@ -246,7 +246,7 @@ for ns in $namespaces; do
         done
 
         # Collecting snapshot info for ceph rbd volumes
-        printf "collecting snapshot info for ceph rbd volumes \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "collecting snapshot info for ceph rbd volumes"
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_vol_and_snap_info
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
@@ -255,7 +255,7 @@ for ns in $namespaces; do
             images=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
             pids_rbd=()
             for image in $images; do
-                printf "collecting vol and snapshot info for %s\n" "${image}" | tee -a "${CEPH_GATHER_DBGLOG}"
+                dbglogf "${CEPH_GATHER_DBGLOG}" "collecting vol and snapshot info for ${image}"
                 {
                     printf "Collecting image info for: %s/%s\n" "${bp}" "${image}"
                     timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log
@@ -267,7 +267,7 @@ for ns in $namespaces; do
             done
             if [ -n "${pids_rbd[*]}" ]; then
                 # wait for all pids
-                echo "waiting for ${pids_rbd[*]} to terminate" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+                dbglog "waiting for ${pids_rbd[*]} to terminate"
                 wait "${pids_rbd[@]}"
             fi
             find "${COMMAND_OUTPUT_DIR}" -name "rbd_vol_and_snap_info_*.part" -print0 | xargs -0 cat >>"${COMMAND_OUTPUT_FILE}"
@@ -277,13 +277,13 @@ for ns in $namespaces; do
         # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
         # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
         while [ "$(ps aux | wc -l)" -gt 100 ]; do
-            printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+            dbglogf "${CEPH_GATHER_DBGLOG}" "waiting for PIDs to be empty before proceeding"
             sleep 2
         done
         # Collecting rbd mirroring info for ceph rbd volumes
-        printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "collecting rbd mirroring info for ceph rbd volumes"
         # Checking snapshot schedule status and list
-        printf "collecting snapshot schedule status and list \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "collecting snapshot schedule status and list"
         { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule status --format=json --pretty-format" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_status; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-status-debug.log 2>&1 &
         pids_ceph+=($!)
         { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule ls --recursive --format=json --pretty-format" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_ls; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-debug.log 2>&1 &
@@ -295,7 +295,7 @@ for ns in $namespaces; do
             isEnabled=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json | jq --raw-output '.mode'")
             if [ "${isEnabled}" != "disabled" ]; then
                 pids_rbd=()
-                printf "Mirroring is enabled on: %s\n" "${bp}" | tee -a "${CEPH_GATHER_DBGLOG}"
+                dbglogf "${CEPH_GATHER_DBGLOG}" "Mirroring is enabled on: ${bp}"
                 {
                     printf "Collecting mirror pool status for: %s\n" "${bp}"
                     timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status --verbose $bp --format=json --pretty-format" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log
@@ -309,7 +309,7 @@ for ns in $namespaces; do
                 printf "Collecting mirror image status for images in: %s\n" "${bp}" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
                 images=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
                 for image in $images; do
-                    printf "Printing information for image: %s\n" "${image}" | tee -a "${CEPH_GATHER_DBGLOG}"
+                    dbglogf "${CEPH_GATHER_DBGLOG}" "Printing information for image: ${image}"
                     {
                         printf "Collecting mirror image status for: %s/%s\n" "${bp}" "${image}"
                         timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json --pretty-format" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log
@@ -318,7 +318,7 @@ for ns in $namespaces; do
                 done
                 if [ -n "${pids_rbd[*]}" ]; then
                     # wait for all pids
-                    echo "waiting for ${pids_rbd[*]} to terminate" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+                    dbglog "waiting for ${pids_rbd[*]} to terminate"
                     wait "${pids_rbd[@]}"
                 fi
                 find "${COMMAND_OUTPUT_DIR}" -name "rbd_mirror_image_status_*.part" -print0 | xargs -0 cat >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
@@ -331,7 +331,7 @@ for ns in $namespaces; do
         done
 
         # Collecting snapshot information for ceph subvolumes
-        printf "collecting snapshot info for cephFS subvolumes \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "collecting snapshot info for cephFS subvolumes"
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/cephfs_subvol_and_snap_info
 
         for fs in $filesystems; do
@@ -356,17 +356,17 @@ for ns in $namespaces; do
                 done
             done
         done
-        printf "waiting for pids to finish \n" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "waiting for pids to finish"
         wait "${pids_ceph[@]}"
     }
     if [ "$(oc get pods --no-headers -n "${ns}" -l must-gather-helper-pod='' | awk '{print $2}')" == "1/1" ]; then
         ceph_collection
     else
-        echo "skipping the ceph collection" | tee -a "${CEPH_GATHER_DBGLOG}"
+        dbglogf "${CEPH_GATHER_DBGLOG}" "skipping the ceph collection"
     fi
     # Collecting output of ceph volume commands
     for ((i = 0; i < ${#ceph_volume_commands[@]}; i++)); do
-        printf "collecting command output for: %s\n" "${ceph_volume_commands[$i]}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "collecting command output for: ${ceph_volume_commands[$i]}"
         for osdPod in $(oc get pods -n "${ns}" -l app=rook-ceph-osd --no-headers | awk '{print $1}'); do
             pod_status=$(oc get po "${osdPod}" -n "${ns}" -o jsonpath='{.status.phase}')
             if [ "${pod_status}" != "Running" ]; then
@@ -386,24 +386,24 @@ for ns in $namespaces; do
 
     # Collecting Ceph daemon logs
     ceph_daemon_log_collection() {
-        printf "collecting Ceph daemon logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "collecting Ceph daemon logs from node ${node}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}-debug" | awk '{print $1}')":/host/var/lib/rook/"${ns}"/log "${CEPH_DAEMON_LOG_OUTPUT_DIR}"
     }
 
     crash_core_collection() {
-        printf "collecting crash core dump from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "collecting crash core dump from node ${node}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/rook/"${ns}"/crash/ "${CRASH_OUTPUT_DIR}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/systemd/coredump/ "${COREDUMP_OUTPUT_DIR}"
     }
 
     journal_collection() {
-        printf "collecting journal logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "collecting journal logs from node ${node}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/log/journal_"${node}".gz "${JOURNAL_OUTPUT_DIR}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/log/kernel_"${node}".gz "${KERNEL_OUTPUT_DIR}"
     }
 
     for node in ${nodes}; do
-        printf "Generating journal logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "Generating journal logs from node ${node}"
         oc debug nodes/"${node}" <<CMDS
             chroot /host
             cd var/log
@@ -415,7 +415,7 @@ CMDS
     # creating a counter variable for collecting PID in array
     pids_log=()
     for node in ${nodes}; do
-        printf "collecting crash, journal and volume logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "collecting crash, journal and volume logs from node ${node}"
         CRASH_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/crash_${node}
         CEPH_DAEMON_LOG_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/ceph_daemon_log_${node}
         JOURNAL_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/journal_${node}
@@ -434,10 +434,10 @@ CMDS
         pids_log+=($!)
         if [ -n "${pids_log[*]}" ]; then
             # wait for all pids
-            echo "waiting for ${pids_log[*]} to terminate" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+            dbglog "waiting for ${pids_log[*]} to terminate"
             wait "${pids_log[@]}"
         fi
-        printf "Deleting journal logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "Deleting journal logs from node ${node}"
         oc debug nodes/"${node}" <<CMDS
             chroot /host
             cd var/log
@@ -447,7 +447,7 @@ CMDS
 CMDS
     done
 
-    echo "ceph core dump collection completed" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+    dbglog "ceph core dump collection completed"
 done
 
 cat "${CEPH_GATHER_DBGLOG}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -6,6 +6,9 @@ BASE_COLLECTION_PATH=$1
 # Expect time option as an argument
 SINCE_TIME=$2
 
+# Source the utils
+. utils.sh
+
 gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
 
 # Use PWD as base path if no argument is passed

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -90,14 +90,14 @@ rados_commands+=("rados ls --pool=ocs-storagecluster-cephfilesystem-metadata --n
 
 # Inspecting ceph related custom resources for all namespaces
 for resource in "${ceph_resources[@]}"; do
-    echo "collecting dump ${resource}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    echo "collecting dump ${resource}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 namespaces=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
 # Inspecting the namespace where ocs-cluster is installed
 for ns in $namespaces; do
-    ceph_collection(){
+    ceph_collection() {
         COMMAND_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/must_gather_commands
         COMMAND_JSON_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/must_gather_commands_json_output
         COMMAND_ERR_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/logs
@@ -108,66 +108,65 @@ for ns in $namespaces; do
         pids_ceph=()
 
         # Collecting output of ceph osd config
-        for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph osd tree --connect-timeout=15 |  grep up "| awk '{print $4}'); do
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph config show $i" >> "${COMMAND_OUTPUT_DIR}/config_$i"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-config-"$i"-debug.log 2>&1 &
+        for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph osd tree --connect-timeout=15 |  grep up " | awk '{print $4}'); do
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph config show $i" >>"${COMMAND_OUTPUT_DIR}/config_$i"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-config-"$i"-debug.log 2>&1 &
             pids_ceph+=($!)
         done
 
         # Collecting output of ceph commands
         for ((i = 0; i < ${#ceph_commands[@]}; i++)); do
-             printf "collecting command output for: %s\n"  "${ceph_commands[$i]}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_commands[$i]// /_}
-             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_commands[$i]// /_}_--format_json-pretty
-             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_commands[$i]}"-debug.log 2>&1 &
-             pids_ceph+=($!)
-             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15 --format json-pretty" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_commands[$i]}"-json-debug.log 2>&1 &
-             pids_ceph+=($!)
+            printf "collecting command output for: %s\n" "${ceph_commands[$i]}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_commands[$i]// /_}
+            JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_commands[$i]// /_}_--format_json-pretty
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_commands[$i]}"-debug.log 2>&1 &
+            pids_ceph+=($!)
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15 --format json-pretty" >>"${JSON_COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_commands[$i]}"-json-debug.log 2>&1 &
+            pids_ceph+=($!)
 
-             # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
-             # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
-             while [ "$(ps aux | wc -l)" -gt 100 ]
-             do
-               printf "waiting for PIDs to be empty before proceeding \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-               sleep 2
-             done
+            # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
+            # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
+            while [ "$(ps aux | wc -l)" -gt 100 ]; do
+                printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                sleep 2
+            done
         done
-        for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph osd lspools --connect-timeout=15"|awk '{print $2}'); do
-             { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $i" >> "${COMMAND_OUTPUT_DIR}/pools_rbd_$i"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-"$i"-debug.log 2>&1 &
-             pids_ceph+=($!)
+        for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph osd lspools --connect-timeout=15" | awk '{print $2}'); do
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $i" >>"${COMMAND_OUTPUT_DIR}/pools_rbd_$i"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-"$i"-debug.log 2>&1 &
+            pids_ceph+=($!)
         done
 
         # Collecting output for ceph subvolume output
-        printf "collecting output for cephFS filesystem\n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting output for cephFS filesystem\n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
         # Inspecting CephFS filesystems
         filesystems=$(timeout 60 oc get cephfilesystems.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
-        
+
         for fs in $filesystems; do
             ceph_command="ceph fs subvolumegroup ls ${fs}"
-            printf "collecting command output for: %s\n"  "${ceph_command}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            printf "collecting command output for: %s\n" "${ceph_command}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_command// /_}
             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_command// /_}_--format_json-pretty
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command} --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_command}"-debug.log 2>&1 &
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_command}"-debug.log 2>&1 &
             pids_ceph+=($!)
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command} --connect-timeout=15 --format json-pretty" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_command}"-json-debug.log 2>&1 &
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command} --connect-timeout=15 --format json-pretty" >>"${JSON_COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${ceph_command}"-json-debug.log 2>&1 &
             pids_ceph+=($!)
-            subvolgrp_name=$(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command}"|awk -F\" '{print $4}')
+            subvolgrp_name=$(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_command}" | awk -F\" '{print $4}')
             for svg in $subvolgrp_name; do
                 subvolume_command="ceph fs subvolume ls ${fs} ${svg}"
-                printf "collecting command output for: %s\n"  "${subvolume_command}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                printf "collecting command output for: %s\n" "${subvolume_command}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
                 COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${subvolume_command// /_}
                 JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${subvolume_command// /_}_--format_json-pretty
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${subvolume_command} --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-"${subvolume_command}"-debug.log 2>&1 &
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${subvolume_command} --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${subvolume_command}"-debug.log 2>&1 &
                 pids_ceph+=($!)
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${subvolume_command} --connect-timeout=15 --format json-pretty" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-"${subvolume_command}"-json-debug.log 2>&1 &
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${subvolume_command} --connect-timeout=15 --format json-pretty" >>"${JSON_COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${subvolume_command}"-json-debug.log 2>&1 &
                 pids_ceph+=($!)
             done
         done
 
         # Collecting output of rados commands
         for ((i = 0; i < ${#rados_commands[@]}; i++)); do
-            printf "collecting command output for: %s\n"  "${rados_commands[$i]}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            printf "collecting command output for: %s\n" "${rados_commands[$i]}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${rados_commands[$i]// /_}
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${rados_commands[$i]} " >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-"${rados_commands[$i]}"-debug.log 2>&1 &
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${rados_commands[$i]} " >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-"${rados_commands[$i]}"-debug.log 2>&1 &
             pids_ceph+=($!)
         done
 
@@ -177,29 +176,29 @@ for ns in $namespaces; do
         printf "Collecting metadata pool name of the filesystem \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
         mdpools=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs ls --format=json | jq '.[] | .metadata_pool'")
         for mdpool in $mdpools; do
-            { printf "Name of the metadata pool: %s\n" "${mdpool}" >> "${COMMAND_OUTPUT_FILE}"; }
+            { printf "Name of the metadata pool: %s\n" "${mdpool}" >>"${COMMAND_OUTPUT_FILE}"; }
             # List omapkeys in csi.volumes.default in filesystem metadata pool
             pvcobjs=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapkeys csi.volumes.default --pool=${mdpool} --namespace=csi")
             # Get the omap details of each PVC object
             for pvcobj in $pvcobjs; do
-                { printf "Name of pvc object: %s\n" "${pvcobj}" >> "${COMMAND_OUTPUT_FILE}"; }
+                { printf "Name of pvc object: %s\n" "${pvcobj}" >>"${COMMAND_OUTPUT_FILE}"; }
                 # getomapval writes the UUID to a file inside helper pod
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados getomapval csi.volumes.default ${pvcobj} --pool=${mdpool} --namespace=csi uuidfile"; }
                 # Get UUID from the file
                 UUID=$(oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "cat uuidfile")
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.volume.${UUID} --pool=${mdpool} --namespace=csi" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${pvcobj}"-debug.log 2>&1 &
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.volume.${UUID} --pool=${mdpool} --namespace=csi" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${pvcobj}"-debug.log 2>&1 &
                 pids_ceph+=($!)
             done
             # List omapkeys in csi.snaps.default in filesystem metadata pool
             snapobjs=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapkeys csi.snaps.default --pool=${mdpool} --namespace=csi")
             # Get the omap details of each snap object
             for snapobj in $snapobjs; do
-                { printf "Name of snap object: %s\n" "${snapobj}" >> "${COMMAND_OUTPUT_FILE}"; }
+                { printf "Name of snap object: %s\n" "${snapobj}" >>"${COMMAND_OUTPUT_FILE}"; }
                 # getomapval writes the UUID to a file inside helper pod
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados getomapval csi.snaps.default ${snapobj} --pool=${mdpool} --namespace=csi uuidfile"; }
                 # Get UUID from the file
                 UUID=$(oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "cat uuidfile")
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.snap.${UUID} --pool=${mdpool} --namespace=csi" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${snapobj}"-debug.log 2>&1 &
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.snap.${UUID} --pool=${mdpool} --namespace=csi" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${snapobj}"-debug.log 2>&1 &
                 pids_ceph+=($!)
             done
         done
@@ -209,85 +208,84 @@ for ns in $namespaces; do
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
         for bp in $blockpools; do
-            { printf "Name of the block pool: %s\n" "${bp}" >> "${COMMAND_OUTPUT_FILE}"; }
+            { printf "Name of the block pool: %s\n" "${bp}" >>"${COMMAND_OUTPUT_FILE}"; }
             # List omapkeys in csi.volumes.default in each block pool
             pvcobjs=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapkeys csi.volumes.default --pool=${bp}")
             # Get the omap details of each PVC object
             for pvcobj in $pvcobjs; do
-                { printf "Name of the pvc object: %s\n" "${pvcobj}" >> "${COMMAND_OUTPUT_FILE}"; }
+                { printf "Name of the pvc object: %s\n" "${pvcobj}" >>"${COMMAND_OUTPUT_FILE}"; }
                 # getomapval writes the UUID to a file inside helper pod
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados getomapval csi.volumes.default ${pvcobj} --pool=${bp} uuidfile" ; }
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados getomapval csi.volumes.default ${pvcobj} --pool=${bp} uuidfile"; }
                 # Get UUID from the file
                 UUID=$(oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "cat uuidfile")
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.volume.${UUID} --pool=${bp}" >> "${COMMAND_OUTPUT_FILE}"; } >>   "${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${pvcobj}"-debug.log 2>&1 &
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.volume.${UUID} --pool=${bp}" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${pvcobj}"-debug.log 2>&1 &
                 pids_ceph+=($!)
             done
             # List omapkeys in csi.snaps.default in the block pool
             snapobjs=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapkeys csi.snaps.default --pool=${bp}")
             # Get the omap details of each snap object
             for snapobj in $snapobjs; do
-                { printf "Name of snap object: %s\n" "${snapobj}" >> "${COMMAND_OUTPUT_FILE}"; }
+                { printf "Name of snap object: %s\n" "${snapobj}" >>"${COMMAND_OUTPUT_FILE}"; }
                 # getomapval writes the UUID to a file inside helper pod
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados getomapval csi.snaps.default ${snapobj} --pool=${bp} uuidfile" ; }
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados getomapval csi.snaps.default ${snapobj} --pool=${bp} uuidfile"; }
                 # Get UUID from the file
                 UUID=$(oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "cat uuidfile")
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.snap.${UUID} --pool=${bp}" >> "${COMMAND_OUTPUT_FILE}"; } >>   "${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${snapobj}"-debug.log 2>&1 &
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rados listomapvals csi.snap.${UUID} --pool=${bp}" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rados-"${snapobj}"-debug.log 2>&1 &
                 pids_ceph+=($!)
             done
         done
 
         # collecting trash list for ceph rbd
-        printf "collecting trash list for ceph rbd \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-         # Inspecting ceph block pools for ceph rbd
+        printf "collecting trash list for ceph rbd \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
         for bp in $blockpools; do
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_trash_ls_"${bp}"
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd trash ls --pool $bp --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-trash-ls-"${bp}"-json-debug.log 2>&1 &
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd trash ls --pool $bp --format=json" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-trash-ls-"${bp}"-json-debug.log 2>&1 &
         done
 
         # Collecting snapshot info for ceph rbd volumes
-        printf "collecting snapshot info for ceph rbd volumes \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting snapshot info for ceph rbd volumes \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_vol_and_snap_info
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
         for bp in $blockpools; do
-            printf "Collecting image and snap info for images in: %s\n" "${bp}" >> "${COMMAND_OUTPUT_FILE}"
+            printf "Collecting image and snap info for images in: %s\n" "${bp}" >>"${COMMAND_OUTPUT_FILE}"
             images=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
             pids_rbd=()
             for image in $images; do
-                printf "collecting vol and snapshot info for %s\n" "${image}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-                { 
-                    printf "Collecting image info for: %s/%s\n" "${bp}" "${image}";
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log;
-                    printf "Collecting snap info for: %s/%s\n" "${bp}" "${image}";
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-"${image}"-debug.log; 
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all --format=json --pretty-format $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-json-"${image}"-debug.log;
-                } >> "${COMMAND_OUTPUT_DIR}"/rbd_vol_and_snap_info_"${image}".part &
+                printf "collecting vol and snapshot info for %s\n" "${image}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                {
+                    printf "Collecting image info for: %s/%s\n" "${bp}" "${image}"
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log
+                    printf "Collecting snap info for: %s/%s\n" "${bp}" "${image}"
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-"${image}"-debug.log
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all --format=json --pretty-format $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-json-"${image}"-debug.log
+                } >>"${COMMAND_OUTPUT_DIR}"/rbd_vol_and_snap_info_"${image}".part &
                 pids_rbd+=($!)
             done
             if [ -n "${pids_rbd[*]}" ]; then
                 # wait for all pids
-                echo "waiting for ${pids_rbd[*]} to terminate" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+                echo "waiting for ${pids_rbd[*]} to terminate" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
                 wait "${pids_rbd[@]}"
             fi
-            find "${COMMAND_OUTPUT_DIR}" -name "rbd_vol_and_snap_info_*.part" -print0 | xargs -0 cat >> "${COMMAND_OUTPUT_FILE}"
-            find "${COMMAND_OUTPUT_DIR}" -name "rbd_vol_and_snap_info_*.part" -print0 | xargs -0 rm -f             
+            find "${COMMAND_OUTPUT_DIR}" -name "rbd_vol_and_snap_info_*.part" -print0 | xargs -0 cat >>"${COMMAND_OUTPUT_FILE}"
+            find "${COMMAND_OUTPUT_DIR}" -name "rbd_vol_and_snap_info_*.part" -print0 | xargs -0 rm -f
         done
 
         # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
         # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
-        while [ "$(ps aux | wc -l)" -gt 100 ]
-            do
-               printf "waiting for PIDs to be empty before proceeding \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-               sleep 2
+        while [ "$(ps aux | wc -l)" -gt 100 ]; do
+            printf "waiting for PIDs to be empty before proceeding \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+            sleep 2
         done
         # Collecting rbd mirroring info for ceph rbd volumes
-        printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
         # Checking snapshot schedule status and list
         printf "collecting snapshot schedule status and list \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule status --format=json --pretty-format" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_status; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-status-debug.log 2>&1 &
+        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule status --format=json --pretty-format" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_status; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-status-debug.log 2>&1 &
         pids_ceph+=($!)
-        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule ls --recursive --format=json --pretty-format" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_ls; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-debug.log 2>&1 &
+        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule ls --recursive --format=json --pretty-format" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_ls; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-debug.log 2>&1 &
         pids_ceph+=($!)
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
@@ -298,36 +296,36 @@ for ns in $namespaces; do
                 pids_rbd=()
                 printf "Mirroring is enabled on: %s\n" "${bp}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
                 {
-                    printf "Collecting mirror pool status for: %s\n" "${bp}";
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status --verbose $bp --format=json --pretty-format" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log;
-                } >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_status &
+                    printf "Collecting mirror pool status for: %s\n" "${bp}"
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status --verbose $bp --format=json --pretty-format" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log
+                } >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_status &
                 pids_rbd+=($!)
                 {
-                    printf "Collecting mirror pool info for: %s\n" "${bp}";
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json --pretty-format" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-info-"${bp}"-debug.log;
-                } >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_info &
+                    printf "Collecting mirror pool info for: %s\n" "${bp}"
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json --pretty-format" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-info-"${bp}"-debug.log
+                } >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_info &
                 pids_rbd+=($!)
-                printf "Collecting mirror image status for images in: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
+                printf "Collecting mirror image status for images in: %s\n" "${bp}" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
                 images=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
                 for image in $images; do
                     printf "Printing information for image: %s\n" "${image}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
                     {
-                        printf "Collecting mirror image status for: %s/%s\n" "${bp}" "${image}";
-                        timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json --pretty-format" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log;
-                    } >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status_"${image}".part &
+                        printf "Collecting mirror image status for: %s/%s\n" "${bp}" "${image}"
+                        timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json --pretty-format" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log
+                    } >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status_"${image}".part &
                     pids_rbd+=($!)
                 done
                 if [ -n "${pids_rbd[*]}" ]; then
                     # wait for all pids
-                    echo "waiting for ${pids_rbd[*]} to terminate" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+                    echo "waiting for ${pids_rbd[*]} to terminate" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
                     wait "${pids_rbd[@]}"
                 fi
-                find "${COMMAND_OUTPUT_DIR}" -name "rbd_mirror_image_status_*.part" -print0 | xargs -0 cat >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
+                find "${COMMAND_OUTPUT_DIR}" -name "rbd_mirror_image_status_*.part" -print0 | xargs -0 cat >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
                 find "${COMMAND_OUTPUT_DIR}" -name "rbd_mirror_image_status_*.part" -print0 | xargs -0 rm -f
             else
-                printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_status
-                printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_info
-                printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
+                printf "Mirroring is disabled on: %s\n" "${bp}" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_status
+                printf "Mirroring is disabled on: %s\n" "${bp}" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_info
+                printf "Mirroring is disabled on: %s\n" "${bp}" >>"${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
             fi
         done
 
@@ -343,69 +341,69 @@ for ns in $namespaces; do
                 # Get the subvolume names from the subvolumegroup name
                 subvols=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs subvolume ls $fs $svg | jq --raw-output '.[].name' ")
                 for subvol in $subvols; do
-                    { printf "Information for subvolume: %s\n" "${subvol}" >> "${COMMAND_OUTPUT_FILE}"; }
-                    { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs subvolume info $fs $subvol $svg --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-ceph-fs-"${subvol}"-debug.log 2>&1 &
+                    { printf "Information for subvolume: %s\n" "${subvol}" >>"${COMMAND_OUTPUT_FILE}"; }
+                    { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs subvolume info $fs $subvol $svg --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-ceph-fs-"${subvol}"-debug.log 2>&1 &
                     pids_ceph+=($!)
                     snaps=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs subvolume snapshot ls $fs $subvol $svg | jq --raw-output '.[].name'")
                     count=$(timeout 60 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs subvolume snapshot ls $fs $subvol $svg | jq --raw-output '.[].name' | wc -l")
-                    { printf "Snapshot count in subvolume: %s=%s\n" "${subvol}" "${count}" >> "${COMMAND_OUTPUT_FILE}"; }
+                    { printf "Snapshot count in subvolume: %s=%s\n" "${subvol}" "${count}" >>"${COMMAND_OUTPUT_FILE}"; }
                     for snap in $snaps; do
-                        { printf "Information for snapshot: %s\n" "${snap}" >> "${COMMAND_OUTPUT_FILE}"; }
-                        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs subvolume snapshot info $fs $subvol $snap $svg --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-ceph-fs-"${subvol}"-"${snap}"-debug.log 2>&1 &
+                        { printf "Information for snapshot: %s\n" "${snap}" >>"${COMMAND_OUTPUT_FILE}"; }
+                        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph fs subvolume snapshot info $fs $subvol $snap $svg --connect-timeout=15" >>"${COMMAND_OUTPUT_FILE}"; } >>"${COMMAND_ERR_OUTPUT_DIR}"/gather-ceph-fs-"${subvol}"-"${snap}"-debug.log 2>&1 &
                         pids_ceph+=($!)
                     done
                 done
             done
         done
-        printf "waiting for pids to finish \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        printf "waiting for pids to finish \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
         wait "${pids_ceph[@]}"
     }
-    if [ "$(oc get pods --no-headers -n "${ns}" -l  must-gather-helper-pod='' | awk '{print $2}')" == "1/1" ] ; then
+    if [ "$(oc get pods --no-headers -n "${ns}" -l must-gather-helper-pod='' | awk '{print $2}')" == "1/1" ]; then
         ceph_collection
     else
-        echo "skipping the ceph collection" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        echo "skipping the ceph collection" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
     fi
     # Collecting output of ceph volume commands
     for ((i = 0; i < ${#ceph_volume_commands[@]}; i++)); do
-        printf "collecting command output for: %s\n"  "${ceph_volume_commands[$i]}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+        printf "collecting command output for: %s\n" "${ceph_volume_commands[$i]}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
         for osdPod in $(oc get pods -n "${ns}" -l app=rook-ceph-osd --no-headers | awk '{print $1}'); do
             pod_status=$(oc get po "${osdPod}" -n "${ns}" -o jsonpath='{.status.phase}')
             if [ "${pod_status}" != "Running" ]; then
                 continue
             fi
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_volume_commands[$i]// /_}
-            { timeout 120 oc -n "${ns}" exec "${osdPod}" -- bash -c "${ceph_volume_commands[$i]}" >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+            { timeout 120 oc -n "${ns}" exec "${osdPod}" -- bash -c "${ceph_volume_commands[$i]}" >>"${COMMAND_OUTPUT_FILE}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
         done
     done
 
-    for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph crash ls --connect-timeout=15"| awk '{print $1}'); do
-        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph crash info $i --connect-timeout=15" >> "${COMMAND_OUTPUT_DIR}"/crash_"${i}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1;
+    for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph crash ls --connect-timeout=15" | awk '{print $1}'); do
+        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph crash info $i --connect-timeout=15" >>"${COMMAND_OUTPUT_DIR}"/crash_"${i}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     done
 
     # Add Ready nodes to the list
     nodes=$(oc get nodes --no-headers | awk '/\yworker\y/{print $1}')
 
     # Collecting Ceph daemon logs
-    ceph_daemon_log_collection(){
-        printf "collecting Ceph daemon logs from node %s \n"  "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}-debug"| awk '{print $1}')":/host/var/lib/rook/"${ns}"/log "${CEPH_DAEMON_LOG_OUTPUT_DIR}"
+    ceph_daemon_log_collection() {
+        printf "collecting Ceph daemon logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}-debug" | awk '{print $1}')":/host/var/lib/rook/"${ns}"/log "${CEPH_DAEMON_LOG_OUTPUT_DIR}"
     }
 
-    crash_core_collection(){
-        printf "collecting crash core dump from node %s \n" "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers  | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/rook/"${ns}"/crash/ "${CRASH_OUTPUT_DIR}"
+    crash_core_collection() {
+        printf "collecting crash core dump from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/rook/"${ns}"/crash/ "${CRASH_OUTPUT_DIR}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/systemd/coredump/ "${COREDUMP_OUTPUT_DIR}"
     }
 
-    journal_collection(){
-        printf "collecting journal logs from node %s \n" "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    journal_collection() {
+        printf "collecting journal logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/log/journal_"${node}".gz "${JOURNAL_OUTPUT_DIR}"
-        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers  | grep "${node//./}"-debug | awk '{print $1}')":/host/var/log/kernel_"${node}".gz "${KERNEL_OUTPUT_DIR}"
-    }  
-    
+        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/log/kernel_"${node}".gz "${KERNEL_OUTPUT_DIR}"
+    }
+
     for node in ${nodes}; do
-        printf "Generating journal logs from node %s \n"  "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-        oc debug nodes/"${node}" << CMDS
+        printf "Generating journal logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        oc debug nodes/"${node}" <<CMDS
             chroot /host
             cd var/log
             journalctl --since "2 days ago" | gzip > journal_"${node}".gz
@@ -416,7 +414,7 @@ CMDS
     # creating a counter variable for collecting PID in array
     pids_log=()
     for node in ${nodes}; do
-        printf "collecting crash, journal and volume logs from node %s \n"  "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+        printf "collecting crash, journal and volume logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
         CRASH_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/crash_${node}
         CEPH_DAEMON_LOG_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/ceph_daemon_log_${node}
         JOURNAL_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/journal_${node}
@@ -435,11 +433,11 @@ CMDS
         pids_log+=($!)
         if [ -n "${pids_log[*]}" ]; then
             # wait for all pids
-            echo "waiting for ${pids_log[*]} to terminate" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+            echo "waiting for ${pids_log[*]} to terminate" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
             wait "${pids_log[@]}"
         fi
-        printf "Deleting journal logs from node %s \n"  "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-        oc debug nodes/"${node}" << CMDS
+        printf "Deleting journal logs from node %s \n" "${node}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+        oc debug nodes/"${node}" <<CMDS
             chroot /host
             cd var/log
             rm -rf journal_"${node}".gz
@@ -448,8 +446,8 @@ CMDS
 CMDS
     done
 
-    echo "ceph core dump collection completed" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    echo "ceph core dump collection completed" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
 done
 
-cat "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
-rm -rf "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+cat "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+rm -rf "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1

--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -10,9 +10,6 @@ fi
 # Expect time option as an argument
 SINCE_TIME=$2
 
-# Source the utils
-. utils.sh
-
 # Command List
 commands_get=()
 

--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -10,6 +10,9 @@ fi
 # Expect time option as an argument
 SINCE_TIME=$2
 
+# Source the utils
+. utils.sh
+
 # Command List
 commands_get=()
 
@@ -62,20 +65,20 @@ mkdir -p "${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/"
 
 # Run the Collection of Resources oc get to list
 for command_get in "${commands_get[@]}"; do
-     echo "collecting oc command ${command_get}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
-     COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/get_${command_get// /_}
-     # shellcheck disable=SC2086
-     { oc get ${command_get}; } >> "${COMMAND_OUTPUT_FILE}"
+    dbglog "collecting oc command ${command_get}"
+    COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/get_${command_get// /_}
+    # shellcheck disable=SC2086
+    { oc get ${command_get}; } >>"${COMMAND_OUTPUT_FILE}"
 done
 
 # Run the Collection of Resources oc yaml to list
 for oc_yaml in "${oc_yamls[@]}"; do
-    { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" --"${SINCE_TIME}" 2>&1; } | dbglog
 done
 
 # Run the Collection of Resources oc describe to list
 for command_desc in "${commands_desc[@]}"; do
-     echo "collecting oc command ${command_desc}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
-     COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/desc_${command_desc// /_}
-    { oc describe "${command_desc}"; } >> "${COMMAND_OUTPUT_FILE}"
+    dbglog "collecting oc command ${command_desc}"
+    COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/desc_${command_desc// /_}
+    { oc describe "${command_desc}"; } >>"${COMMAND_OUTPUT_FILE}"
 done

--- a/must-gather/collection-scripts/gather_common_ceph_resources
+++ b/must-gather/collection-scripts/gather_common_ceph_resources
@@ -6,9 +6,6 @@ BASE_COLLECTION_PATH=$1
 # Expect time option as an argument
 SINCE_TIME=$2
 
-# Source the utils
-. utils.sh
-
 # Use PWD as base path if no argument is passed
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)

--- a/must-gather/collection-scripts/gather_common_ceph_resources
+++ b/must-gather/collection-scripts/gather_common_ceph_resources
@@ -6,6 +6,9 @@ BASE_COLLECTION_PATH=$1
 # Expect time option as an argument
 SINCE_TIME=$2
 
+# Source the utils
+. utils.sh
+
 # Use PWD as base path if no argument is passed
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
@@ -20,6 +23,6 @@ common_ceph_resources+=(cephobjectstoreusers)
 common_ceph_resources+=(cephclusters)
 
 for resource in "${common_ceph_resources[@]}"; do
-    echo "collecting dump ${resource}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    dbglog "collecting dump ${resource}"
+    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 done

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -10,6 +10,9 @@ fi
 # Expect time option as an argument
 SINCE_TIME=$2
 
+# Source the utils
+. utils.sh
+
 # Make a global variable for namespace
 INSTALL_NAMESPACES=$(oc get storagecluster -A --no-headers | awk '{print $1}')
 PRODUCT_NAMESPACE=$(oc get managedFusionOffering -A --no-headers | awk '{print $1}')
@@ -86,12 +89,12 @@ oc_yamls+=("prometheus")
 oc_yamls+=("alertmanagerconfig")
 
 for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_NAMESPACE $OPERATOR_NAMESPACE; do
-     echo "collecting dump of namespace ${INSTALL_NAMESPACE}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
-     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
-     echo "collecting dump of clusterresourceversion" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+     dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
+     { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+     dbglog "collecting dump of clusterresourceversion"
      for oc_yaml in "${oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+          { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -99,7 +102,7 @@ for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_
 
      # Run the Collection of Resources to list
      for command_get in "${commands_get[@]}"; do
-          echo "collecting oc command ${command_get}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+          dbglog "collecting oc command ${command_get}"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${command_get// /_}
           # shellcheck disable=SC2086
           { oc get ${command_get} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
@@ -107,7 +110,7 @@ for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_
 
      # Run the Collection of OC desc commands
      for command_desc in "${commands_desc[@]}"; do
-          echo "collecting oc describe command ${command_desc}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+          dbglog "collecting oc describe command ${command_desc}"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${command_desc// /_}
           # shellcheck disable=SC2086
           { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
@@ -124,28 +127,28 @@ mkdir -p "${BASE_COLLECTION_PATH}/namespaces/all/"
 
 # Run the Collection of Resources using must-gather
 for resource in "${resources[@]}"; do
-     echo "collecting dump of ${resource}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
-     { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+     dbglog "collecting dump of ${resource}"
+     { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 done
 
 { timeout 60 oc get ns openshift-dr-system; }
 # Verify if openshift-dr-system namespace exists
 if [ $? == 0 ]; then
-     echo "collecting dump of openshift-dr-system namespace" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
-     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${RAMEN_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+     dbglog "collecting dump of openshift-dr-system namespace"
+     { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${RAMEN_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
 
      # Create the dir for oc_output for openshift-dr-system namespace
      mkdir -p "${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/"
 
      # Run the Collection of Resources to list
      for dr_resource in "${dr_resources[@]}"; do
-          echo "collecting oc command ${dr-resource}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+          dbglog "collecting oc command ${dr-resource}"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/${dr_resource// /_}
           # shellcheck disable=SC2086
           { oc get ${dr_resource} -n ${RAMEN_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
      done
      # Run collection of oc describe command for config map
-     echo "collecting oc describe configmap -n ${RAMEN_NAMESPACE}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+     dbglog "collecting oc describe configmap -n ${RAMEN_NAMESPACE}"
      COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/desc_configmap
      # shellcheck disable=SC2086
      { oc describe configmap -n ${RAMEN_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
@@ -154,33 +157,33 @@ else
 fi
 
 # For pvc of all namespaces
-echo "collecting dump of oc get pvc all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get pvc all namespaces"
 { oc get pvc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 
 # For volumesnapshot of all namespaces
-echo "collecting dump of oc get volumesnapshot all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get volumesnapshot all namespaces"
 { oc get volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
 { oc describe volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 
 # For obc of all namespaces
-echo "collecting dump of oc get obc all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get obc all namespaces"
 { oc get obc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect obc --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect obc --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 
 # For VolumeReplication of all namespaces
-echo "collecting dump of oc get volumereplication all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get volumereplication all namespaces"
 { oc get volumereplication --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vr_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumereplication --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumereplication --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 
 # For VolumeReplicationGroups of all namespaces
-echo "collecting dump of oc get volumereplicationgroups all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get volumereplicationgroups all namespaces"
 { oc get volumereplicationgroups --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vrg_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect vrg --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect vrg --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
 
 # Collect details of storageclassclaim of all namespaces for managed services
-echo "collecting dump of oc get storageclassclaim all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get storageclassclaim all namespaces"
 if [ "$(oc get storageclassclaim --no-headers -A | awk '{print $2}')" != "" ]; then
      { oc get storageclassclaim --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_storageclassclaim_all_ns"
      { oc describe storageclassclaim --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_storageclassclaim_all_ns"
@@ -188,28 +191,28 @@ if [ "$(oc get storageclassclaim --no-headers -A | awk '{print $2}')" != "" ]; t
 fi
 
 # Collect csi-addons object details of all namespaces
-echo "collecting dump of oc get csiaddonsnode all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get csiaddonsnode all namespaces"
 if [ "$(oc get csiaddonsnode --no-headers -A | awk '{print $2}')" != "" ]; then
      { oc get csiaddonsnode --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_csiaddonsnode_all_ns"
      { oc describe csiaddonsnode --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_csiaddonsnode_all_ns"
      { oc get csiaddonsnode -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_csiaddonsnode_all_ns"
 fi
 
-echo "collecting dump of oc get reclaimspacejob all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get reclaimspacejob all namespaces"
 if [ "$(oc get reclaimspacejob --no-headers -A | awk '{print $1}')" != "" ]; then
      { oc get reclaimspacejob --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_reclaimspacejob_all_ns"
      { oc describe reclaimspacejob --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_reclaimspacejob_all_ns"
      { oc get reclaimspacejob -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_reclaimspacejob_all_ns"
 fi
 
-echo "collecting dump of oc get reclaimspacecronjobs all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get reclaimspacecronjobs all namespaces"
 if [ "$(oc get reclaimspacejob --no-headers -A | awk '{print $1}')" != "" ]; then
      { oc get reclaimspacecronjobs --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_reclaimspacecronjobs_all_ns"
      { oc describe reclaimspacecronjobs --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_reclaimspacecronjobs_all_ns"
      { oc get reclaimspacecronjobs -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_reclaimspacecronjobs_all_ns"
 fi
 
-echo "collecting dump of oc get networkfence all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+dbglog "collecting dump of oc get networkfence all namespaces"
 if [ "$(oc get networkfence --no-headers -A | awk '{print $1}')" != "" ]; then
      { oc get networkfence --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_networkfence_all_ns"
      { oc describe networkfence --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_networkfence_all_ns"

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -4,13 +4,13 @@ BASE_COLLECTION_PATH=$1
 
 # Use PWD as base path if no argument is passed
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
-    BASE_COLLECTION_PATH=$(pwd)
+     BASE_COLLECTION_PATH=$(pwd)
 fi
 
 # Expect time option as an argument
 SINCE_TIME=$2
 
-# Make a globle variable for namespace
+# Make a global variable for namespace
 INSTALL_NAMESPACES=$(oc get storagecluster -A --no-headers | awk '{print $1}')
 PRODUCT_NAMESPACE=$(oc get managedFusionOffering -A --no-headers | awk '{print $1}')
 OPERATOR_NAMESPACE=$(oc get subscription -A --no-headers | awk '{print $1}' | grep odf-operator)
@@ -86,12 +86,12 @@ oc_yamls+=("prometheus")
 oc_yamls+=("alertmanagerconfig")
 
 for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_NAMESPACE $OPERATOR_NAMESPACE; do
-     echo "collecting dump of namespace ${INSTALL_NAMESPACE}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
-     echo "collecting dump of clusterresourceversion" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+     echo "collecting dump of namespace ${INSTALL_NAMESPACE}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+     echo "collecting dump of clusterresourceversion" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
      for oc_yaml in "${oc_yamls[@]}"; do
-     # shellcheck disable=SC2129
-     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+          # shellcheck disable=SC2129
+          oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
      done
 
      # Create the dir for oc_output
@@ -102,7 +102,7 @@ for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_
           echo "collecting oc command ${command_get}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${command_get// /_}
           # shellcheck disable=SC2086
-          { oc get ${command_get} -n ${INSTALL_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
+          { oc get ${command_get} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
      done
 
      # Run the Collection of OC desc commands
@@ -110,29 +110,29 @@ for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_
           echo "collecting oc describe command ${command_desc}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${command_desc// /_}
           # shellcheck disable=SC2086
-          { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
+          { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
      done
 done
 
 # NOTE: This is a temporary fix for collecting the storagecluster as we are not able to collect the storagecluster using the inspect command
-{ oc get storageclusters -n "${INSTALL_NAMESPACE}" -o yaml; } > "$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/storagecluster.yaml" 2>&1
-{ oc get storagesystem -n "${INSTALL_NAMESPACE}" -o yaml; } > "$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/storagesystem.yaml" 2>&1
-{ oc get storageconsumer -n "${INSTALL_NAMESPACE}" -o yaml; } > "$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/storageconsumer.yaml" 2>&1
+{ oc get storageclusters -n "${INSTALL_NAMESPACE}" -o yaml; } >"$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/storagecluster.yaml" 2>&1
+{ oc get storagesystem -n "${INSTALL_NAMESPACE}" -o yaml; } >"$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/storagesystem.yaml" 2>&1
+{ oc get storageconsumer -n "${INSTALL_NAMESPACE}" -o yaml; } >"$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/storageconsumer.yaml" 2>&1
 
 # Create the dir for data from all namespaces
 mkdir -p "${BASE_COLLECTION_PATH}/namespaces/all/"
 
 # Run the Collection of Resources using must-gather
 for resource in "${resources[@]}"; do
-    echo "collecting dump of ${resource}" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-    { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+     echo "collecting dump of ${resource}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+     { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 done
 
 { timeout 60 oc get ns openshift-dr-system; }
 # Verify if openshift-dr-system namespace exists
 if [ $? == 0 ]; then
-     echo "collecting dump of openshift-dr-system namespace" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${RAMEN_NAMESPACE}" --"${SINCE_TIME}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+     echo "collecting dump of openshift-dr-system namespace" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${RAMEN_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 
      # Create the dir for oc_output for openshift-dr-system namespace
      mkdir -p "${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/"
@@ -142,76 +142,76 @@ if [ $? == 0 ]; then
           echo "collecting oc command ${dr-resource}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/${dr_resource// /_}
           # shellcheck disable=SC2086
-          { oc get ${dr_resource} -n ${RAMEN_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
+          { oc get ${dr_resource} -n ${RAMEN_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
      done
      # Run collection of oc describe command for config map
      echo "collecting oc describe configmap -n ${RAMEN_NAMESPACE}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
      COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/desc_configmap
      # shellcheck disable=SC2086
-     { oc describe configmap -n ${RAMEN_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
+     { oc describe configmap -n ${RAMEN_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
 else
      { printf "No openshift-dr-system namespace"; }
-fi    
+fi
 
 # For pvc of all namespaces
-echo "collecting dump of oc get pvc all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-{ oc get pvc --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+echo "collecting dump of oc get pvc all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+{ oc get pvc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 
 # For volumesnapshot of all namespaces
-echo "collecting dump of oc get volumesnapshot all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-{ oc get volumesnapshot --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
-{ oc describe volumesnapshot --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+echo "collecting dump of oc get volumesnapshot all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+{ oc get volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
+{ oc describe volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 
 # For obc of all namespaces
-echo "collecting dump of oc get obc all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-{ oc get obc --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect obc --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+echo "collecting dump of oc get obc all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+{ oc get obc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect obc --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 
 # For VolumeReplication of all namespaces
-echo "collecting dump of oc get volumereplication all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-{ oc get volumereplication --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/vr_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumereplication --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+echo "collecting dump of oc get volumereplication all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+{ oc get volumereplication --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vr_all_namespaces"
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumereplication --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 
 # For VolumeReplicationGroups of all namespaces
-echo "collecting dump of oc get volumereplicationgroups all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-{ oc get volumereplicationgroups --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/vrg_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect vrg --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+echo "collecting dump of oc get volumereplicationgroups all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+{ oc get volumereplicationgroups --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vrg_all_namespaces"
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect vrg --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 
 # Collect details of storageclassclaim of all namespaces for managed services
-echo "collecting dump of oc get storageclassclaim all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-if [ "$(oc get storageclassclaim --no-headers -A | awk '{print $2}')" != "" ] ; then
-     { oc get storageclassclaim --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_storageclassclaim_all_ns"
-     { oc describe storageclassclaim --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_storageclassclaim_all_ns"
-     { oc get storageclassclaim -oyaml --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_storageclassclaim_all_ns"
+echo "collecting dump of oc get storageclassclaim all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+if [ "$(oc get storageclassclaim --no-headers -A | awk '{print $2}')" != "" ]; then
+     { oc get storageclassclaim --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_storageclassclaim_all_ns"
+     { oc describe storageclassclaim --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_storageclassclaim_all_ns"
+     { oc get storageclassclaim -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_storageclassclaim_all_ns"
 fi
 
 # Collect csi-addons object details of all namespaces
-echo "collecting dump of oc get csiaddonsnode all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-if [ "$(oc get csiaddonsnode --no-headers -A | awk '{print $2}')" != "" ] ; then
-     { oc get csiaddonsnode --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_csiaddonsnode_all_ns"
-     { oc describe csiaddonsnode --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_csiaddonsnode_all_ns"
-     { oc get csiaddonsnode -oyaml --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_csiaddonsnode_all_ns"
+echo "collecting dump of oc get csiaddonsnode all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+if [ "$(oc get csiaddonsnode --no-headers -A | awk '{print $2}')" != "" ]; then
+     { oc get csiaddonsnode --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_csiaddonsnode_all_ns"
+     { oc describe csiaddonsnode --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_csiaddonsnode_all_ns"
+     { oc get csiaddonsnode -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_csiaddonsnode_all_ns"
 fi
 
-echo "collecting dump of oc get reclaimspacejob all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-if [ "$(oc get reclaimspacejob --no-headers -A | awk '{print $1}')" != "" ] ; then
-     { oc get reclaimspacejob --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_reclaimspacejob_all_ns"
-     { oc describe reclaimspacejob --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_reclaimspacejob_all_ns"
-     { oc get reclaimspacejob -oyaml --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_reclaimspacejob_all_ns"
+echo "collecting dump of oc get reclaimspacejob all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+if [ "$(oc get reclaimspacejob --no-headers -A | awk '{print $1}')" != "" ]; then
+     { oc get reclaimspacejob --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_reclaimspacejob_all_ns"
+     { oc describe reclaimspacejob --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_reclaimspacejob_all_ns"
+     { oc get reclaimspacejob -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_reclaimspacejob_all_ns"
 fi
 
-echo "collecting dump of oc get reclaimspacecronjobs all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-if [ "$(oc get reclaimspacejob --no-headers -A | awk '{print $1}')" != "" ] ; then
-     { oc get reclaimspacecronjobs --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_reclaimspacecronjobs_all_ns"
-     { oc describe reclaimspacecronjobs --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_reclaimspacecronjobs_all_ns"
-     { oc get reclaimspacecronjobs -oyaml --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_reclaimspacecronjobs_all_ns"
+echo "collecting dump of oc get reclaimspacecronjobs all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+if [ "$(oc get reclaimspacejob --no-headers -A | awk '{print $1}')" != "" ]; then
+     { oc get reclaimspacecronjobs --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_reclaimspacecronjobs_all_ns"
+     { oc describe reclaimspacecronjobs --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_reclaimspacecronjobs_all_ns"
+     { oc get reclaimspacecronjobs -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_reclaimspacecronjobs_all_ns"
 fi
 
-echo "collecting dump of oc get networkfence all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-if [ "$(oc get networkfence --no-headers -A | awk '{print $1}')" != "" ] ; then
-     { oc get networkfence --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_networkfence_all_ns"
-     { oc describe networkfence --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_networkfence_all_ns"
-     { oc get networkfence -oyaml --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_networkfence_all_ns"
+echo "collecting dump of oc get networkfence all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+if [ "$(oc get networkfence --no-headers -A | awk '{print $1}')" != "" ]; then
+     { oc get networkfence --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_networkfence_all_ns"
+     { oc describe networkfence --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_networkfence_all_ns"
+     { oc get networkfence -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_networkfence_all_ns"
 fi

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -10,9 +10,6 @@ fi
 # Expect time option as an argument
 SINCE_TIME=$2
 
-# Source the utils
-. utils.sh
-
 # Make a global variable for namespace
 INSTALL_NAMESPACES=$(oc get storagecluster -A --no-headers | awk '{print $1}')
 PRODUCT_NAMESPACE=$(oc get managedFusionOffering -A --no-headers | awk '{print $1}')

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -3,9 +3,6 @@
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
-# Source the utils
-. utils.sh
-
 # Expect time option as an argument
 SINCE_TIME=$2
 

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -3,6 +3,9 @@
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
+# Source the utils
+. utils.sh
+
 # Expect time option as an argument
 SINCE_TIME=$2
 
@@ -38,46 +41,45 @@ mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/}"
 # Run the Collection of Noobaa cli using must-gather
 # shellcheck disable=SC2086
 for cli in "${noobaa_cli[@]}"; do
-    echo "collecting dump of ${cli}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    dbglog "collecting dump of ${cli}"
     COMMAND_OUTPUT_FILE="${NOOBAA_COLLLECTION_PATH}"/raw_output/${cli// /_}
-    { timeout 180 noobaa ${cli} --namespace openshift-storage >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { timeout 180 noobaa ${cli} --namespace openshift-storage >>"${COMMAND_OUTPUT_FILE}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
-noobaa diagnose --dir "${NOOBAA_COLLLECTION_PATH}"/raw_output/ --namespace openshift-storage  >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+noobaa diagnose --dir "${NOOBAA_COLLLECTION_PATH}"/raw_output/ --namespace openshift-storage >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 
 # Run the Collection of NooBaa Resources using must-gather
 for resource in "${noobaa_resources[@]}"; do
-    echo "collecting dump of ${resource}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-    { oc adm --dest-dir="${NOOBAA_COLLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    dbglog "collecting dump of ${resource}"
+    { oc adm --dest-dir="${NOOBAA_COLLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Collect logs for all noobaa pods using oc logs
 # get all namespaces that contain any noobaa pod
 NOOBAA_PODS_LABEL='app in (noobaa)'
-for ns in $(oc get pod --all-namespaces -l "${NOOBAA_PODS_LABEL}" | grep -v NAMESPACE | awk '{print $1}' | uniq)
-do
+for ns in $(oc get pod --all-namespaces -l "${NOOBAA_PODS_LABEL}" | grep -v NAMESPACE | awk '{print $1}' | uniq); do
     #get logs for all pods with label app=noobaa
     for pod in $(oc -n "${ns}" get pod -l "${NOOBAA_PODS_LABEL}" | grep -v NAME | awk '{print $1}'); do
-        echo "collecting dump of ${pod} pod from ${ns}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+        dbglog "collecting dump of ${pod} pod from ${ns}"
         LOG_DIR=${NOOBAA_COLLLECTION_PATH}/logs/${ns}
         mkdir -p "${LOG_DIR}"
-        { timeout 120 oc -n "${ns}" logs --all-containers "${pod}" &> "${LOG_DIR}"/"${pod}".log; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+        { timeout 120 oc -n "${ns}" logs --all-containers "${pod}" &>"${LOG_DIR}"/"${pod}".log; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     done
 done
 
 # Collecting noobaa db pod logs with postgres label
 NOOBAA_POSTGRES_LABEL='noobaa-db in (postgres)'
 for pod in $(oc -n "${ns}" get pods -l "${NOOBAA_POSTGRES_LABEL}" | grep -v NAME | awk '{print $1}'); do
-    echo "collecting noobaa db pod logs from ${ns}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
-    { timeout 120 oc -n "${ns}" logs --all-containers "${pod}" &> "${LOG_DIR}"/"${pod}".log; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    dbglog "collecting noobaa db pod logs from ${ns}"
+    { timeout 120 oc -n "${ns}" logs --all-containers "${pod}" &>"${LOG_DIR}"/"${pod}".log; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Add important notifications to a notifications.txt file at the root of the noobaa collection path
 UNMANAGED_NOOBAA_NOTIF="The noobaa deployed on this cluster is not managed by the storagecluster CR and will not react to configuration changes made to storagecluster CR"
 
-NOOBAA_RECONCILE_STRATEGY=$( oc -n "${ns}" get storagecluster -o jsonpath='{.items[0].spec.multiCloudGateway.reconcileStrategy}' 2> /dev/null)
+NOOBAA_RECONCILE_STRATEGY=$(oc -n "${ns}" get storagecluster -o jsonpath='{.items[0].spec.multiCloudGateway.reconcileStrategy}' 2>/dev/null)
 if [ "${NOOBAA_RECONCILE_STRATEGY}" = "ignore" ] || [ "${NOOBAA_RECONCILE_STRATEGY}" = "standalone" ]; then
-    if [ "$(oc -n "${ns}" get noobaa -o name 2> /dev/null)" ]; then
-        echo "- ${UNMANAGED_NOOBAA_NOTIF}" >> "${NOOBAA_COLLLECTION_PATH}/notifications.txt"
+    if [ "$(oc -n "${ns}" get noobaa -o name 2>/dev/null)" ]; then
+        echo "- ${UNMANAGED_NOOBAA_NOTIF}" >>"${NOOBAA_COLLLECTION_PATH}/notifications.txt"
     fi
 fi
 
@@ -86,8 +88,8 @@ mkdir -p "${NOOBAA_COLLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/"
 
 # Run the Collection of OC desc commands for noobaa
 for noobaa_desc in "${noobaa_desc[@]}"; do
-     echo "collecting oc describe command ${noobaa_desc}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
-     COMMAND_OUTPUT_FILE=${NOOBAA_COLLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${noobaa_desc// /_}
-     # shellcheck disable=SC2086
-     { oc describe ${noobaa_desc} -n ${INSTALL_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
+    dbglog "collecting oc describe command ${noobaa_desc}"
+    COMMAND_OUTPUT_FILE=${NOOBAA_COLLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${noobaa_desc// /_}
+    # shellcheck disable=SC2086
+    { oc describe ${noobaa_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
 done

--- a/must-gather/collection-scripts/pre-install.sh
+++ b/must-gather/collection-scripts/pre-install.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 # Expect base collection path as an argument
+# shellcheck disable=SC2034
 BASE_COLLECTION_PATH="${1}"
-
-# Source the utils
-. utils.sh
 
 ns=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
 

--- a/must-gather/collection-scripts/pre-install.sh
+++ b/must-gather/collection-scripts/pre-install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+# Expect base collection path as an argument
 BASE_COLLECTION_PATH="${1}"
+
+# Source the utils
+. utils.sh
 
 ns=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
 

--- a/must-gather/collection-scripts/pre-install.sh
+++ b/must-gather/collection-scripts/pre-install.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
+BASE_COLLECTION_PATH="${1}"
+
 ns=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
 
 POD_TEMPLATE="/templates/pod.template"
 
-SED_DELIMITER=$(echo -en "\001");
-safe_replace () {
+SED_DELIMITER=$(echo -en "\001")
+safe_replace() {
     sed "s${SED_DELIMITER}${1}${SED_DELIMITER}${2}${SED_DELIMITER}g"
 }
 
 apply_helper_pod() {
-    < ${POD_TEMPLATE} safe_replace "NAMESPACE" "$1" | safe_replace "IMAGE_NAME" "$2" | safe_replace "MUST_GATHER" "$HOSTNAME" > pod_helper.yaml
+    safe_replace <${POD_TEMPLATE} "NAMESPACE" "$1" | safe_replace "IMAGE_NAME" "$2" | safe_replace "MUST_GATHER" "$HOSTNAME" >pod_helper.yaml
     oc apply -f pod_helper.yaml
 }
 
@@ -21,60 +23,60 @@ nodes=$(oc get nodes --no-headers | awk '/\yworker\y/{print $1}')
 storageClusterPresent=$(oc get storagecluster -n "${ns}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
 # checking for mcg standalone cluster
 reconcileStrategy=$(oc get storagecluster -n "${ns}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
-deploy(){
-     operatorImage=$(oc get pods -l app=rook-ceph-operator -n "${ns}" -o jsonpath="{range .items[*]}{@.spec.containers[0].image}+{end}" | tr "+" "\n" | head -n1)
-     if [ -z "${storageClusterPresent}" ]; then
-        echo "not creating helper pod since storagecluster is not present" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-     elif [ "${operatorImage}" = "" ]; then
-        echo "not able to find the rook's operator image. Skipping collection of ceph command output" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-     elif [ "${reconcileStrategy}" = "standalone" ]; then
-        echo "not creating helper pod as this is a MCG only cluster" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-     else
-          echo "creating helper pod" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-          apply_helper_pod "$ns" "$operatorImage"
-     fi
+deploy() {
+    operatorImage=$(oc get pods -l app=rook-ceph-operator -n "${ns}" -o jsonpath="{range .items[*]}{@.spec.containers[0].image}+{end}" | tr "+" "\n" | head -n1)
+    if [ -z "${storageClusterPresent}" ]; then
+        dbglog "not creating helper pod since storagecluster is not present"
+    elif [ "${operatorImage}" = "" ]; then
+        dbglog "not able to find the rook's operator image. Skipping collection of ceph command output"
+    elif [ "${reconcileStrategy}" = "standalone" ]; then
+        dbglog "not creating helper pod as this is a MCG only cluster"
+    else
+        dbglog "creating helper pod"
+        apply_helper_pod "$ns" "$operatorImage"
+    fi
 
-     for node in ${nodes}; do
-          oc debug nodes/"${node}" --to-namespace="${ns}" -- bash -c "sleep 100m" &
-          printf "debugging node %s \n" "${node}"
-     done
+    for node in ${nodes}; do
+        oc debug nodes/"${node}" --to-namespace="${ns}" -- bash -c "sleep 100m" &
+        printf "debugging node %s \n" "${node}"
+    done
 }
 
-labels(){
+labels() {
     if [ -n "${storageClusterPresent}" ] && [ "${reconcileStrategy}" != "standalone" ]; then
-     oc label pod -n "${ns}" "${HOSTNAME}"-helper must-gather-helper-pod=''
+        oc label pod -n "${ns}" "${HOSTNAME}"-helper must-gather-helper-pod=''
     fi
 }
 
-check_for_debug_pod(){
+check_for_debug_pod() {
     debug_pod_name=$(oc get pods -n "${ns}" | grep "${node//./}-debug" | awk '{print $1}')
     # sleep for 60 seconds giving time for debug pod to get created
     sleep 60
     oc wait -n "${ns}" --for=condition=Ready pod/"$debug_pod_name" --timeout=200s
-    if [ "$(oc get pods -n "${ns}" | grep "${node//./}-debug" | awk '{print $2}')" == "1/1" ] ; then
+    if [ "$(oc get pods -n "${ns}" | grep "${node//./}-debug" | awk '{print $2}')" == "1/1" ]; then
         oc label -n "${ns}" pod "$debug_pod_name" "${node//./}"-debug='ready'
     fi
 }
 
-check_for_helper_pod(){
+check_for_helper_pod() {
     # sleep for 60 seconds giving time for helper pod to get created
     sleep 60
     oc wait -n "${ns}" --for=condition=Ready pod/"${HOSTNAME}"-helper --timeout=200s
 }
 
 cleanup() {
-  echo "checking for existing must-gather resource" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
-  pods=$(oc get pods --no-headers -n "${ns}" -l must-gather-helper-pod='' | awk '{print $1}')
-  if [ -n "${storageClusterPresent}" ] && [ -n "${pods}" ]; then
-    SAVEIFS=$IFS # Save current IFS
-    IFS=$'\n'    # Change IFS to new line
-    pods=("$pods") # split to array $pods
-    IFS=$SAVEIFS # Restore IFS
-    echo "deleting existing must-gather resource" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
-    for pod in "${pods[@]}"; do
-      oc delete pod "${pod}" -n "${ns}"
-    done
-  fi
+    dbglog "checking for existing must-gather resource"
+    pods=$(oc get pods --no-headers -n "${ns}" -l must-gather-helper-pod='' | awk '{print $1}')
+    if [ -n "${storageClusterPresent}" ] && [ -n "${pods}" ]; then
+        SAVEIFS=$IFS   # Save current IFS
+        IFS=$'\n'      # Change IFS to new line
+        pods=("$pods") # split to array $pods
+        IFS=$SAVEIFS   # Restore IFS
+        dbglog "deleting existing must-gather resource"
+        for pod in "${pods[@]}"; do
+            oc delete pod "${pod}" -n "${ns}"
+        done
+    fi
 }
 
 cleanup
@@ -92,6 +94,6 @@ done
 
 # wait for all pids
 if [ -n "${pids[*]}" ]; then
-    echo "waiting for ${pids[*]} to terminate" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    dbglog "waiting for ${pids[*]} to terminate"
     wait "${pids[@]}"
 fi

--- a/must-gather/collection-scripts/utils.sh
+++ b/must-gather/collection-scripts/utils.sh
@@ -4,7 +4,10 @@
 # Please Note:
 # While using bash variables inside the functions defined here,
 # ensure that the variable has been defined before,
-# you call the realted helper function.
+# you call the related helper function.
+#
+# Also, to prevent sourcing the file everywhere, please export the functions
+# you define here using `export -f <function_name>`
 #
 
 dbglog() {
@@ -28,3 +31,7 @@ dbglogf() {
 
     echo -e "${msg}" | tee -a "${1}"
 }
+
+# Export the functions so that the file needs to be sourced only once
+export -f dbglog
+export -f dbglogf

--- a/must-gather/collection-scripts/utils.sh
+++ b/must-gather/collection-scripts/utils.sh
@@ -23,6 +23,7 @@ dbglogf() {
 
     if [[ -z $1 || -z $msg ]]; then
         echo "dbglogf: Not enough args to call the function."
+        exit 1
     fi
 
     echo -e "${msg}" | tee -a "${1}"

--- a/must-gather/collection-scripts/utils.sh
+++ b/must-gather/collection-scripts/utils.sh
@@ -3,10 +3,27 @@
 #
 # Please Note:
 # While using bash variables inside the functions defined here,
-# ensure that the variable has been defined before you,
-# call the realted helper function.
+# ensure that the variable has been defined before,
+# you call the realted helper function.
 #
 
 dbglog() {
-    echo -e "${1}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+    # Allow the input to be piped
+    declare msg=${1:-$(</dev/stdin)}
+
+    echo -e "${msg}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+}
+
+# Works similar to dbglog but accepts a custom file name as an arg
+# 1st arg is the file name to write to
+# 2nd arg is the message to append
+dbglogf() {
+    # Allow the input to be piped
+    declare msg=${2:-$(</dev/stdin)}
+
+    if [[ -z $1 || -z $msg ]]; then
+        echo "dbglogf: Not enough args to call the function."
+    fi
+
+    echo -e "${msg}" | tee -a "${1}"
 }

--- a/must-gather/collection-scripts/utils.sh
+++ b/must-gather/collection-scripts/utils.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+#
+# Please Note:
+# While using bash variables inside the functions defined here,
+# ensure that the variable has been defined before you,
+# call the realted helper function.
+#
+
+dbglog() {
+    echo -e "${1}" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+}


### PR DESCRIPTION
Using echo and then piping it to a log file is a pattern that can be seen throughout this project. Doing so requires quite a log of syntax.

The idea is to have a file with common utility functions and source them at the beginning of the run.

We already pass `BASE_COLLECTION_PATH` as an argument to every script so this approach is just building on top of that.

Another fix included in this patch is for out of scope variable reference at preinstall.sh:29. Shell scripts do not carry over variable definitions.