### PR TITLE
Bug 2215917: collect the status for RBD-images

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -259,6 +259,8 @@ for ns in $namespaces; do
                 { 
                     printf "Collecting image info for: %s/%s\n" "${bp}" "${image}";
                     timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log;
+                    printf "Collecting image status for: %s/%s\n" "${bp}" "${image}";
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd status $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-status-"${image}"-debug.log;
                     printf "Collecting snap info for: %s/%s\n" "${bp}" "${image}";
                     timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-"${image}"-debug.log; 
                     timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all --format=json --pretty-format $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-json-"${image}"-debug.log;


### PR DESCRIPTION
In addition to `rbd info` and `rbd snap ls --all`, collect the output of `rbd status` too.

See-also: https://bugzilla.redhat.com/2215917