### PR TITLE
Use ENV to determine the interpreter path

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 BASE_COLLECTION_PATH="must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-BASE_COLLECTION_PATH="must-gather"
 
 export BASE_COLLECTION_PATH="must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1

--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 

--- a/must-gather/collection-scripts/gather_common_ceph_resources
+++ b/must-gather/collection-scripts/gather_common_ceph_resources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1

--- a/must-gather/collection-scripts/post-uninstall.sh
+++ b/must-gather/collection-scripts/post-uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 namespace=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
 reconcileStrategy=$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')

--- a/must-gather/collection-scripts/pre-install.sh
+++ b/must-gather/collection-scripts/pre-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Expect base collection path as an argument
 # shellcheck disable=SC2034


### PR DESCRIPTION
This approach is preferred on systems where the path of the interpreter might not be the one we defined.

We do not use interpreter args anywhere in this project and hence this patch can be applied as a drop-in replacement. This makes the project more portable and in sync with OpenShift mg.