### PR TITLE
Improve handling of BASE_COLLECTION_PATH

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,5 +1,5 @@
 #!/bin/bash
-BASE_COLLECTION_PATH="must-gather"
+export BASE_COLLECTION_PATH="must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 
 # Command line argument

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -1,17 +1,13 @@
 #!/bin/bash
 
-# Expect base collection path as an argument
-BASE_COLLECTION_PATH=$1
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 # Expect time option as an argument
 SINCE_TIME=$2
 
 gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
-
-# Use PWD as base path if no argument is passed
-if [ "${BASE_COLLECTION_PATH}" = "" ]; then
-    BASE_COLLECTION_PATH=$(pwd)
-fi
 
 CEPH_GATHER_DBGLOG="${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
 CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
@@ -256,14 +252,14 @@ for ns in $namespaces; do
             pids_rbd=()
             for image in $images; do
                 dbglogf "${CEPH_GATHER_DBGLOG}" "collecting vol and snapshot info for ${image}"
-                { 
-                    printf "Collecting image info for: %s/%s\n" "${bp}" "${image}";
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log;
-                    printf "Collecting image status for: %s/%s\n" "${bp}" "${image}";
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd status $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-status-"${image}"-debug.log;
-                    printf "Collecting snap info for: %s/%s\n" "${bp}" "${image}";
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-"${image}"-debug.log; 
-                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all --format=json --pretty-format $image --pool $bp" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-json-"${image}"-debug.log;
+                {
+                    printf "Collecting image info for: %s/%s\n" "${bp}" "${image}"
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log
+                    printf "Collecting image status for: %s/%s\n" "${bp}" "${image}"
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd status $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-status-"${image}"-debug.log
+                    printf "Collecting snap info for: %s/%s\n" "${bp}" "${image}"
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-"${image}"-debug.log
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all --format=json --pretty-format $image --pool $bp" 2>>"${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-json-"${image}"-debug.log
                 } >>"${COMMAND_OUTPUT_DIR}"/rbd_vol_and_snap_info_"${image}".part &
                 pids_rbd+=($!)
             done

--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -1,11 +1,7 @@
 #!/bin/bash
-# Expect base collection path as an argument
-BASE_COLLECTION_PATH=$1
-
-# Use PWD as base path if no argument is passed
-if [ "${BASE_COLLECTION_PATH}" = "" ]; then
-    BASE_COLLECTION_PATH=$(pwd)
-fi
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 # Expect time option as an argument
 SINCE_TIME=$2

--- a/must-gather/collection-scripts/gather_common_ceph_resources
+++ b/must-gather/collection-scripts/gather_common_ceph_resources
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-# Expect base collection path as an argument
-BASE_COLLECTION_PATH=$1
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 # Expect time option as an argument
 SINCE_TIME=$2
-
-# Use PWD as base path if no argument is passed
-if [ "${BASE_COLLECTION_PATH}" = "" ]; then
-    BASE_COLLECTION_PATH=$(pwd)
-fi
 
 CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
 

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -1,11 +1,7 @@
 #!/bin/bash
-# Expect base collection path as an argument
-BASE_COLLECTION_PATH=$1
-
-# Use PWD as base path if no argument is passed
-if [ "${BASE_COLLECTION_PATH}" = "" ]; then
-     BASE_COLLECTION_PATH=$(pwd)
-fi
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 # Expect time option as an argument
 SINCE_TIME=$2
@@ -188,11 +184,11 @@ if [ "$(oc get storageclassclaim --no-headers -A | awk '{print $2}')" != "" ]; t
 fi
 
 # Collect details of managedfusionoffering of all namespaces for managed services
-echo "collecting dump of oc get managedfusionoffering all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-if [ "$(oc get managedfusionoffering --no-headers -A | awk '{print $1}')" != "" ] ; then
-     { oc get managedfusionoffering --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_managedfusionoffering_all_ns"
-     { oc describe managedfusionoffering --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_managedfusionoffering_all_ns"
-     { oc get managedfusionoffering -oyaml --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_managedfusionoffering_all_ns"
+echo "collecting dump of oc get managedfusionoffering all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+if [ "$(oc get managedfusionoffering --no-headers -A | awk '{print $1}')" != "" ]; then
+     { oc get managedfusionoffering --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_managedfusionoffering_all_ns"
+     { oc describe managedfusionoffering --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_managedfusionoffering_all_ns"
+     { oc get managedfusionoffering -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_managedfusionoffering_all_ns"
 fi
 
 # Collect csi-addons object details of all namespaces
@@ -224,8 +220,8 @@ if [ "$(oc get networkfence --no-headers -A | awk '{print $1}')" != "" ]; then
      { oc get networkfence -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_networkfence_all_ns"
 fi
 
-echo "collecting network-attachment-definitions of oc get network-attachment-definitions all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
-if [ "$(oc get network-attachment-definitions --no-headers -A | awk '{print $1}')" != "" ] ; then
-     { oc get network-attachment-definitions -oyaml --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_net_attach_def_all_ns"
-     { oc describe network-attachment-definitions --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_net_attach_def_all_ns"
+echo "collecting network-attachment-definitions of oc get network-attachment-definitions all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+if [ "$(oc get network-attachment-definitions --no-headers -A | awk '{print $1}')" != "" ]; then
+     { oc get network-attachment-definitions -oyaml --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_yaml_net_attach_def_all_ns"
+     { oc describe network-attachment-definitions --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_net_attach_def_all_ns"
 fi

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-# Expect base collection path as an argument
-BASE_COLLECTION_PATH=$1
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 # Expect time option as an argument
 SINCE_TIME=$2
-
-# Use PWD as base path if no argument is passed
-if [ "${BASE_COLLECTION_PATH}" = "" ]; then
-    BASE_COLLECTION_PATH=$(pwd)
-fi
 
 # Make a global variable for namespace
 INSTALL_NAMESPACE=openshift-storage

--- a/must-gather/collection-scripts/pre-install.sh
+++ b/must-gather/collection-scripts/pre-install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Expect base collection path as an argument
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
 # shellcheck disable=SC2034
-BASE_COLLECTION_PATH="${1}"
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 ns=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
 


### PR DESCRIPTION
And its resolution in case it is not defined. We never call any of the collection scripts without them expecting basepath unless being called explicitly from the container.

In that case, it will resolve to PWD and the script will execute as expected without any overlaps as exported shell variables have a TTL until they are subprocesses of the current shell.