### PR TITLE
Export SINCE_TIME for use in sub scripts

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -3,7 +3,7 @@ export BASE_COLLECTION_PATH="must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 
 # Command line argument
-SINCE_TIME=$1
+export SINCE_TIME=$1
 
 # Source the utils
 # shellcheck disable=SC1091
@@ -18,9 +18,9 @@ dbglog "collection started at: ${START_TIME}"
 pre-install.sh ${BASE_COLLECTION_PATH}
 
 # Call other gather scripts
-gather_namespaced_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
-gather_clusterscoped_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
-gather_noobaa_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
+gather_namespaced_resources ${BASE_COLLECTION_PATH}
+gather_clusterscoped_resources ${BASE_COLLECTION_PATH}
+gather_noobaa_resources ${BASE_COLLECTION_PATH}
 
 namespace=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
 storageClusterPresent=$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
@@ -29,14 +29,14 @@ reconcileStrategy=$(oc get storagecluster -n "${namespace}" -o go-template='{{ra
 
 if [ "${externalStorageClusterPresent}" == true ]; then
     dbglog "Collecting limited ceph logs since external cluster is present"
-    gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
+    gather_common_ceph_resources "${BASE_COLLECTION_PATH}"
 elif [ -z "${storageClusterPresent}" ]; then
     dbglog "Skipping ceph collection as Storage Cluster is not present"
 elif [ "${reconcileStrategy}" = "standalone" ]; then
     dbglog "Skipping ceph collection as this is a MCG only cluster"
 else
     dbglog "Collecting entire ceph logs"
-    gather_ceph_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
+    gather_ceph_resources ${BASE_COLLECTION_PATH}
 fi
 
 # Call post-uninstall.sh

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -4,9 +4,6 @@
 # If it is not defined, use PWD instead
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
-# Expect time option as an argument
-SINCE_TIME=$2
-
 gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
 
 CEPH_GATHER_DBGLOG="${BASE_COLLECTION_PATH}"/gather-ceph-debug.log

--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -3,9 +3,6 @@
 # If it is not defined, use PWD instead
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
-# Expect time option as an argument
-SINCE_TIME=$2
-
 # Command List
 commands_get=()
 

--- a/must-gather/collection-scripts/gather_common_ceph_resources
+++ b/must-gather/collection-scripts/gather_common_ceph_resources
@@ -4,9 +4,6 @@
 # If it is not defined, use PWD instead
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
-# Expect time option as an argument
-SINCE_TIME=$2
-
 CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
 
 # common Ceph resources

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -3,9 +3,6 @@
 # If it is not defined, use PWD instead
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
-# Expect time option as an argument
-SINCE_TIME=$2
-
 # Make a global variable for namespace
 INSTALL_NAMESPACES=$(oc get storagecluster -A --no-headers | awk '{print $1}')
 PRODUCT_NAMESPACE=$(oc get managedFusionOffering -A --no-headers | awk '{print $1}')

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -4,9 +4,6 @@
 # If it is not defined, use PWD instead
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
-# Expect time option as an argument
-SINCE_TIME=$2
-
 # Make a global variable for namespace
 INSTALL_NAMESPACE=openshift-storage
 


### PR DESCRIPTION
Optimize `SINCE_TIME` access by exporting it as a variable. Saves us from passing it around and manually accessing it.