### PR TITLE
remove sort-by flag from events desc

### DIFF
--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -115,7 +115,7 @@ done
 # Collect oc get events with sorted timestamp
 dbglog "collecting output of oc get events with sorted timestamp"
 { oc get event -o custom-columns="LAST SEEN:{lastTimestamp},FIRST SEEN:{firstTimestamp},COUNT:{count},NAME:{metadata.name},KIND:{involvedObject.kind},SUBOBJECT:{involvedObject.fieldPath},TYPE:{type},REASON:{reason},SOURCE:{source.component},MESSAGE:{message}" --sort-by=lastTimestamp -nopenshift-storage; } >"$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/events_get" 2>&1
-{ oc describe events -n openshift-storage --sort-by=lastTimestamp; } >"$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/events_desc" 2>&1
+{ oc describe events -n openshift-storage; } >"$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/events_desc" 2>&1
 { oc get events -n openshift-storage -o yaml; } >"$BASE_COLLECTION_PATH/namespaces/${INSTALL_NAMESPACE}/oc_output/events_yaml" 2>&1
 
 # Create the dir for data from all namespaces


### PR DESCRIPTION
This commit removes the sort-by flag from
oc describe events collection