### PR TITLE
remove provider call in default op mode

### DIFF
--- a/collection-scripts/gather_main
+++ b/collection-scripts/gather_main
@@ -12,7 +12,7 @@ procids+=($!)
 gather_noobaa_resources &
 procids+=($!)
 
-gather_odf_client &
+gather_ceph_logs &
 procids+=($!)
 
 gather_ceph_pod_logs &


### PR DESCRIPTION
We need not call provider script in default mod, so removing it from the main call.
We also need to collect ceph_logs in default op,
it was missing