### PR TITLE
Add arg for collecting ODF logs

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -85,7 +85,7 @@ display_help() {
 Usage: $0 [OPTIONS]
 
 Options:
-  -o,  --odf                Collect ODF logs (default operation mode)
+  -o,  --odf                Collect ODF logs
   -d,  --dr                 Collect DR logs
   -p,  --provider           Collect logs for provider/consumer cluster
   -n,  --nooba              Collect nooba logs

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Predefined operating modes
+odf=false
 dr=false
 pc=false
 nooba=false
@@ -16,6 +17,11 @@ pids=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+    -o | --odf)
+        odf=true
+        default=false
+        shift
+        ;;
     -d | --dr)
         dr=true
         default=false
@@ -79,6 +85,7 @@ display_help() {
 Usage: $0 [OPTIONS]
 
 Options:
+  -o,  --odf                Collect ODF logs (default operation mode)
   -d,  --dr                 Collect DR logs
   -p,  --provider           Collect logs for provider/consumer cluster
   -n,  --nooba              Collect nooba logs
@@ -129,6 +136,12 @@ if [ "$help" = true ]; then
 fi
 
 # Process the options
+if [ "$odf" == true ]; then
+    echo "Collect ODF logs..."
+    gather_main &
+    pids+=($!)
+fi
+
 if [ "$dr" == true ]; then
     echo "Collect DR logs..."
     gather_dr_resources ${BASE_COLLECTION_PATH} &
@@ -183,7 +196,7 @@ fi
 
 # No args, normal op mode
 if [ "$default" = true ]; then
-    echo "Gather will start in default op mode"
+    echo "No args detected, must-gather will start in default op mode"
     gather_main
 fi
 


### PR DESCRIPTION
Supposed to be used in conjunction with other args as it makes no sense to use it standalone. Passing `-o` or `--odf` will include the data from `deafult` op mode along with other data requested by the remaining args.