### PR TITLE
update readme to include correct flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ oc adm must-gather --image=registry.redhat.io/odf4/odf-must-gather-rhel9:v4.13 -
 List of arguments that can be passed to the odf-must-gather are:
 ```
 -d,  --dr                 Collect DR logs
--p,  --provider           Collect logs for provider/consumer cluster
+-pc,  --provider          Collect openshift-storage-client logs from a provider/consumer cluster
 -n,  --nooba              Collect nooba logs
 -c,  --ceph               Collect ceph commands and pod logs
 -cl, --ceph-logs          Collect ceph daemon, kernel, journal logs and crash reports


### PR DESCRIPTION
recently the flag name for provider/consumer cluster was changed. Updating the same in the Readme file too.