### PR TITLE
Add ceph-logs-since flag

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-export CEPH_LOGS_SINCE_HOURS=48

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export CEPH_LOGS_SINCE_HOURS=48

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -12,12 +12,10 @@ clusterscoped=false
 help=false
 default=true
 
+export CEPH_LOGS_SINCE_HOURS="48"
+
 # Store PIDs of all the subprocesses
 pids=()
-
-# Source the common
-# shellcheck disable=SC1091
-. common.sh
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -58,8 +56,7 @@ while [[ $# -gt 0 ]]; do
             echo "Error: -cls argument value must be an integer (number of hours)"
             exit 1
         else
-            CEPH_LOGS_SINCE_HOURS="$1"
-            echo "CEPH_LOGS_SINCE_HOURS={$CEPH_LOGS_SINCE_HOURS}"
+            export CEPH_LOGS_SINCE_HOURS="$1"
             shift
         fi
         ;;

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -15,6 +15,10 @@ default=true
 # Store PIDs of all the subprocesses
 pids=()
 
+# Source the common
+# shellcheck disable=SC1091
+. common.sh
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
     -o | --odf)
@@ -46,6 +50,18 @@ while [[ $# -gt 0 ]]; do
         cephlogs=true
         default=false
         shift
+        ;;
+    -cls | --ceph-logs-since)
+        shift
+        # Check if cls argument value is an integer
+        if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+            echo "Error: -cls argument value must be an integer (number of hours)"
+            exit 1
+        else
+            CEPH_LOGS_SINCE_HOURS="$1"
+            echo "CEPH_LOGS_SINCE_HOURS={$CEPH_LOGS_SINCE_HOURS}"
+            shift
+        fi
         ;;
     -ns | --namespaced)
         namespaced=true

--- a/collection-scripts/gather_ceph_logs
+++ b/collection-scripts/gather_ceph_logs
@@ -30,11 +30,11 @@ for ns in $namespaces; do
     }
 
     for node in ${nodes}; do
-        dbglog "Generating journal logs from node ${node}"
+        dbglog "Generating journal logs from node ${node} since ${CEPH_LOGS_SINCE_HOURS} hours ago"
         oc debug nodes/"${node}" <<CMDS
             chroot /host
             cd var/log
-            journalctl --since "2 days ago" | gzip > journal_"${node}".gz
+            journalctl --since "${CEPH_LOGS_SINCE_HOURS} hours ago" | gzip > journal_"${node}".gz
             journalctl -k -o short-iso-precise --utc --no-hostname | gzip > kernel_"${node}".gz
             exit
 CMDS


### PR DESCRIPTION
I added an argument  to collect the jouranlctl for the specific period [Hours]
For example:
-cls [--ceph-logs-since] =3
we will run: ` journalctl --since "3 hours ago" `

https://bugzilla.redhat.com/show_bug.cgi?id=2261986#c31

tested it on private image:
```
$ oc adm must-gather --image=quay.io/oviner/ocs-must-gather:since10 -- /usr/bin/gather -cls 3

[must-gather-l28n7] POD 2024-03-10T12:21:07.702906584Z Pod IP: 10.1.161.44
[must-gather-l28n7] POD 2024-03-10T12:21:07.702906584Z If you don't see a command prompt, try pressing enter.
[must-gather-l28n7] POD 2024-03-10T12:21:07.722972522Z collecting oc command scc
[must-gather-l28n7] POD 2024-03-10T12:21:07.784955725Z sh: cannot set terminal process group (433158): Inappropriate ioctl for device
[must-gather-l28n7] POD 2024-03-10T12:21:07.784955725Z sh: no job control in this shell
[must-gather-l28n7] POD 2024-03-10T12:21:07.786757966Z sh-5.1#             cd var/log
[must-gather-l28n7] POD 2024-03-10T12:21:07.786757966Z sh-5.1#             journalctl --since "3 hours ago" | gzip > journal_"compute-0"
".gz
[must-gather-l28n7] POD 2024-03-10T12:21:07.812399162Z sh-5.1#             journalctl -k -o short-iso-precise --utc --no-hostname | gzip
p > kernel_"compute-0".gz
[must-gather-l28n7] POD 2024-03-10T12:21:07.859527055Z sh-5.1#             exit
[must-gather-l28n7] POD 2024-03-10T12:21:07.859874580Z exit
[must-gather-l28n7] POD 2024-03-10T12:21:07.863188658Z 
[must-gather-l28n7] POD 2024-03-10T12:21:07.863188658Z Removing debug pod ...
[must-gather-l28n7] POD 2024-03-10T12:21:07.874412620Z Wrote inspect data to must-gather/ceph.



```

