### PR TITLE
Fix order of args supplied to oc adm inspect

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -120,9 +120,6 @@ fi
 export BASE_COLLECTION_PATH="must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 
-# Command line argument
-export SINCE_TIME=$1
-
 # Source the utils
 # shellcheck disable=SC1091
 . utils.sh

--- a/collection-scripts/gather_ceph_resources
+++ b/collection-scripts/gather_ceph_resources
@@ -4,7 +4,7 @@
 # If it is not defined, use PWD instead
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
-gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
+gather_common_ceph_resources "${BASE_COLLECTION_PATH}"
 CEPH_GATHER_DBGLOG="${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
 CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
 
@@ -85,7 +85,7 @@ rados_commands+=("rados ls --pool=ocs-storagecluster-cephfilesystem-metadata --n
 # Inspecting ceph related custom resources for all namespaces
 for resource in "${ceph_resources[@]}"; do
     dbglog "collecting dump ${resource}"
-    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+    { oc adm inspect --dest-dir="${CEPH_COLLECTION_PATH}" --all-namespaces "${resource}" 2>&1; } | dbglog
 done
 
 namespaces=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)

--- a/collection-scripts/gather_clusterscoped_resources
+++ b/collection-scripts/gather_clusterscoped_resources
@@ -66,7 +66,7 @@ done
 
 # Run the Collection of Resources oc yaml to list
 for oc_yaml in "${oc_yamls[@]}"; do
-    { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" --"${SINCE_TIME}" 2>&1; } | dbglog
+    { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
 done
 
 # Run the Collection of Resources oc describe to list

--- a/collection-scripts/gather_common_ceph_resources
+++ b/collection-scripts/gather_common_ceph_resources
@@ -14,5 +14,5 @@ common_ceph_resources+=(cephclusters)
 
 for resource in "${common_ceph_resources[@]}"; do
     dbglog "collecting dump ${resource}"
-    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+    { oc adm inspect --dest-dir="${CEPH_COLLECTION_PATH}" --all-namespaces "${resource}" 2>&1; } | dbglog
 done

--- a/collection-scripts/gather_dr_resources
+++ b/collection-scripts/gather_dr_resources
@@ -28,7 +28,7 @@ dr_resources+=(configmap)
 dr_resources+=(pods -owide)
 
 dbglog "collecting dump of openshift-dr-system namespace"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+{ oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${NAMESPACE}" 2>&1; } | dbglog
 
 # Create the dir for oc_output for openshift-dr-system namespace
 mkdir -p "${BASE_COLLECTION_PATH}/namespaces/${NAMESPACE}/oc_output/"

--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -76,11 +76,11 @@ oc_yamls+=("alertmanagerconfig")
 
 for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_NAMESPACE $OPERATOR_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      dbglog "collecting dump of clusterresourceversion"
      for oc_yaml in "${oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -112,8 +112,8 @@ dbglog "collecting output of oc get events with sorted timestamp"
 { oc get event -o custom-columns="LAST SEEN:{lastTimestamp},FIRST SEEN:{firstTimestamp},COUNT:{count},NAME:{metadata.name},KIND:{involvedObject.kind},SUBOBJECT:{involvedObject.fieldPath},TYPE:{type},REASON:{reason},SOURCE:{source.component},MESSAGE:{message}" --sort-by=lastTimestamp -n openshift-storage; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/events_get" 2>&1
 events=$(timeout 60 oc get events -n openshift-storage -o custom-columns="NAME:{metadata.name}" --sort-by=lastTimestamp --no-headers)
 for event in $events; do
-     { oc describe events "${event}" -n openshift-storage; } >> "${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/events_desc"
-     { oc get events "${event}" -n openshift-storage -o yaml; } >> "${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/events_yaml"
+     { oc describe events "${event}" -n openshift-storage; } >>"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/events_desc"
+     { oc get events "${event}" -n openshift-storage -o yaml; } >>"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/events_yaml"
 done
 
 # Create the dir for data from all namespaces
@@ -122,34 +122,34 @@ mkdir -p "${BASE_COLLECTION_PATH}/namespaces/all/"
 # Run the Collection of Resources using must-gather
 for resource in "${resources[@]}"; do
      dbglog "collecting dump of ${resource}"
-     { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+     { oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${resource}" 2>&1; } | dbglog
 done
 
 # For pvc of all namespaces
 dbglog "collecting dump of oc get pvc all namespaces"
 { oc get pvc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" pvc 2>&1; } | dbglog
 
 # For volumesnapshot of all namespaces
 dbglog "collecting dump of oc get volumesnapshot all namespaces"
 { oc get volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
 { oc describe volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" volumesnapshot 2>&1; } | dbglog
 
 # For obc of all namespaces
 dbglog "collecting dump of oc get obc all namespaces"
 { oc get obc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect obc --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" obc 2>&1; } | dbglog
 
 # For VolumeReplication of all namespaces
 dbglog "collecting dump of oc get volumereplication all namespaces"
 { oc get volumereplication --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vr_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumereplication --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" volumereplication 2>&1; } | dbglog
 
 # For VolumeReplicationGroups of all namespaces
 dbglog "collecting dump of oc get volumereplicationgroups all namespaces"
 { oc get volumereplicationgroups --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vrg_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect vrg --all-namespaces --"${SINCE_TIME}" 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" vrg 2>&1; } | dbglog
 
 # Collect details of storageclassclaim of all namespaces for managed services
 dbglog "collecting dump of oc get storageclassclaim all namespaces"

--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -33,7 +33,7 @@ mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/}"
 
 # Save the information of all Postgres DBs in the NooBaa DB pod
 dbglog "Collecting MCG database information..."
-oc rsh --namespace openshift-storage noobaa-db-pg-0 psql -d nbcore -c '\pset pager off' -c '\x on' -c '\list+' &> "${NOOBAA_COLLLECTION_PATH}"/raw_output/db_list.txt 2>&1
+oc rsh --namespace openshift-storage noobaa-db-pg-0 psql -d nbcore -c '\pset pager off' -c '\x on' -c '\list+' &>"${NOOBAA_COLLLECTION_PATH}"/raw_output/db_list.txt 2>&1
 
 # Run the Collection of Noobaa cli using must-gather
 # shellcheck disable=SC2086
@@ -47,7 +47,7 @@ noobaa diagnose --dir "${NOOBAA_COLLLECTION_PATH}"/raw_output/ --namespace opens
 # Run the Collection of NooBaa Resources using must-gather
 for resource in "${noobaa_resources[@]}"; do
     dbglog "collecting dump of ${resource}"
-    { oc adm --dest-dir="${NOOBAA_COLLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { oc adm inspect --all-namespaces --dest-dir="${NOOBAA_COLLLECTION_PATH}" "${resource}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Collect logs for all noobaa pods using oc logs

--- a/collection-scripts/gather_odf_client
+++ b/collection-scripts/gather_odf_client
@@ -4,7 +4,6 @@
 # If it is not defined, use PWD instead
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
-
 STORAGE_CLIENT_NAMESPACE=$(oc get storageclients -A --no-headers | awk '{print $1}')
 CLIENT_OPERATOR_NAMESPACE=$(oc get subscriptions -A --no-headers | grep ocs-client-operator | awk '{print $1}')
 
@@ -52,14 +51,13 @@ client_commands_desc=()
 client_commands_desc+=("storageclients")
 client_commands_desc+=("storageclassclaims")
 
-
-for INSTALL_NAMESPACE in  $CLIENT_OPERATOR_NAMESPACE ; do
+for INSTALL_NAMESPACE in $CLIENT_OPERATOR_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      # Run the Collection of oc yaml outputs
      for oc_yaml in "${oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -78,17 +76,17 @@ for INSTALL_NAMESPACE in  $CLIENT_OPERATOR_NAMESPACE ; do
           dbglog "collecting oc describe command ${command_desc}"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${command_desc// /_}
           # shellcheck disable=SC2086
-          { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}" 
+          { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
      done
 done
 
-for INSTALL_NAMESPACE in  $STORAGE_CLIENT_NAMESPACE ; do
+for INSTALL_NAMESPACE in $STORAGE_CLIENT_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      # Run the Collection of oc yaml outputs
      for oc_yaml in "${client_oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -107,7 +105,7 @@ for INSTALL_NAMESPACE in  $STORAGE_CLIENT_NAMESPACE ; do
           dbglog "collecting oc describe command ${command_desc}"
           COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/${command_desc// /_}
           # shellcheck disable=SC2086
-          { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}" 
+          { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
      done
 done
 


### PR DESCRIPTION
According to the spec oc cli expects the args to inspect
in the format: `oc adm inspect <args> <resource>`

Adapt the project according to the spec.

This patch also removes `SINCE_TIME` var as it served no purpose in its current form.

Regards