### PR TITLE
Add support for --since and --since-time flags

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -124,10 +124,17 @@ mkdir -p ${BASE_COLLECTION_PATH}
 # shellcheck disable=SC1091
 . utils.sh
 
+# Parse the ENV for collection filters
+parse_since_time
+
 # timestamp for starting of the script
 START_TIME=$(date +%r)
 start=$(date +%s)
 dbglog "collection started at: ${START_TIME}"
+
+if [ -n "${LOG_FILTER_ARGS:-}" ]; then
+    dbglog "Logs will be filtered using: ${LOG_FILTER_ARGS}"
+fi
 
 # Call pre-install.sh, see commit msg
 pre-install.sh ${BASE_COLLECTION_PATH}

--- a/collection-scripts/gather_ceph_logs
+++ b/collection-scripts/gather_ceph_logs
@@ -34,8 +34,8 @@ for ns in $namespaces; do
         oc debug nodes/"${node}" <<CMDS
             chroot /host
             cd var/log
-            journalctl --since "2 days ago" | gzip > journal_"${node}".gz
-            journalctl -k -o short-iso-precise --utc --no-hostname | gzip > kernel_"${node}".gz
+            journalctl --since "${JCTL_FILTER_ARGS}" | gzip > journal_"${node}".gz
+            journalctl --since "${JCTL_FILTER_ARGS}" -k -o short-iso-precise --utc --no-hostname | gzip > kernel_"${node}".gz
             exit
 CMDS
     done

--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -76,11 +76,11 @@ oc_yamls+=("alertmanagerconfig")
 
 for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_NAMESPACE $OPERATOR_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      dbglog "collecting dump of clusterresourceversion"
      for oc_yaml in "${oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -122,34 +122,34 @@ mkdir -p "${BASE_COLLECTION_PATH}/namespaces/all/"
 # Run the Collection of Resources using must-gather
 for resource in "${resources[@]}"; do
      dbglog "collecting dump of ${resource}"
-     { oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${resource}" 2>&1; } | dbglog
+     { oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" "${resource}" 2>&1; } | dbglog
 done
 
 # For pvc of all namespaces
 dbglog "collecting dump of oc get pvc all namespaces"
 { oc get pvc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" pvc 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" pvc 2>&1; } | dbglog
 
 # For volumesnapshot of all namespaces
 dbglog "collecting dump of oc get volumesnapshot all namespaces"
 { oc get volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
 { oc describe volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" volumesnapshot 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" volumesnapshot 2>&1; } | dbglog
 
 # For obc of all namespaces
 dbglog "collecting dump of oc get obc all namespaces"
 { oc get obc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" obc 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" obc 2>&1; } | dbglog
 
 # For VolumeReplication of all namespaces
 dbglog "collecting dump of oc get volumereplication all namespaces"
 { oc get volumereplication --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vr_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" volumereplication 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" volumereplication 2>&1; } | dbglog
 
 # For VolumeReplicationGroups of all namespaces
 dbglog "collecting dump of oc get volumereplicationgroups all namespaces"
 { oc get volumereplicationgroups --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vrg_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" vrg 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" vrg 2>&1; } | dbglog
 
 # Collect details of storageclassclaim of all namespaces for managed services
 dbglog "collecting dump of oc get storageclassclaim all namespaces"

--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -47,7 +47,7 @@ noobaa diagnose --dir "${NOOBAA_COLLLECTION_PATH}"/raw_output/ --namespace opens
 # Run the Collection of NooBaa Resources using must-gather
 for resource in "${noobaa_resources[@]}"; do
     dbglog "collecting dump of ${resource}"
-    { oc adm inspect --all-namespaces --dest-dir="${NOOBAA_COLLLECTION_PATH}" "${resource}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { oc adm inspect --all-namespaces --dest-dir="${NOOBAA_COLLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${resource}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Collect logs for all noobaa pods using oc logs

--- a/collection-scripts/gather_odf_client
+++ b/collection-scripts/gather_odf_client
@@ -53,11 +53,11 @@ client_commands_desc+=("storageclassclaims")
 
 for INSTALL_NAMESPACE in $CLIENT_OPERATOR_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      # Run the Collection of oc yaml outputs
      for oc_yaml in "${oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -82,11 +82,11 @@ done
 
 for INSTALL_NAMESPACE in $STORAGE_CLIENT_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      # Run the Collection of oc yaml outputs
      for oc_yaml in "${client_oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output

--- a/collection-scripts/utils.sh
+++ b/collection-scripts/utils.sh
@@ -32,6 +32,33 @@ dbglogf() {
     echo -e "${msg}" | tee -a "${1}"
 }
 
+# Read the `MUST_GATHER_SINCE` and `MUST_GATHER_SINCE_TIME`
+# from the ENV and export it for use in the gather scripts
+#
+# Acc to spec, only one of `MUST_GATHER_SINCE`
+# or `MUST_GATHER_SINCE_TIME` can be used.
+parse_since_time() {
+    local FILTER_ARGS=""
+
+    # We do not need to validate the values here, they are validated
+    # by the oc cli.
+    # Ref: https://github.com/openshift/oc/commit/1fc5c7d79ff5c2fa19c35b7a004dc99eb3330806
+    if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+        FILTER_ARGS="--since=${MUST_GATHER_SINCE}"
+    fi
+
+    if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+        FILTER_ARGS="--since-time=${MUST_GATHER_SINCE_TIME}"
+    fi
+
+    # It is possible that user is not providing any filters
+    # We do not export the variable in that case
+    if [ -n "${FILTER_ARGS}" ]; then
+        export LOG_FILTER_ARGS="${FILTER_ARGS}"
+    fi
+}
+
 # Export the functions so that the file needs to be sourced only once
 export -f dbglog
 export -f dbglogf
+export -f parse_since_time

--- a/collection-scripts/utils.sh
+++ b/collection-scripts/utils.sh
@@ -56,6 +56,27 @@ parse_since_time() {
     if [ -n "${FILTER_ARGS}" ]; then
         export LOG_FILTER_ARGS="${FILTER_ARGS}"
     fi
+
+    # Journalctl doesn't support the same type of since and
+    # since-time args. Adapt the logic for journalctl
+    local JRNL_FILTER=""
+
+    if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+        JRNL_FILTER="${MUST_GATHER_SINCE} ago"
+    fi
+
+    # This section adapts an ISO time like: 2024-04-04T09:23:26Z
+    # To 2024-04-04 09:23:26, a format that journalctl is happy with
+    if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+        JRNL_FILTER=$(echo "${MUST_GATHER_SINCE_TIME}" | sed 's/T/ /; s/Z//')
+    fi
+
+    # If the var is unset, export the default as 2 days ago
+    if [ -n "${JRNL_FILTER}" ]; then
+        export JCTL_FILTER_ARGS="${JRNL_FILTER}"
+    else
+        export JCTL_FILTER_ARGS="2 days ago"
+    fi
 }
 
 # Export the functions so that the file needs to be sourced only once


### PR DESCRIPTION
The must-gather now filters its logs based on the above parameters. The said parameters are provided by the OC cli as ENV values.