### PR TITLE
csi: must-gather for volumegroupsnapshot

### DIFF
--- a/collection-scripts/gather_clusterscoped_resources
+++ b/collection-scripts/gather_clusterscoped_resources
@@ -21,6 +21,8 @@ commands_get+=("scc")
 commands_get+=("volumereplicationclass")
 commands_get+=("volumesnapshotclass")
 commands_get+=("volumesnapshotcontent")
+commands_get+=("volumegroupsnapshotclass")
+commands_get+=("volumegroupsnapshotcontent")
 
 # collect yaml output of OC commands
 oc_yamls=()
@@ -37,6 +39,8 @@ oc_yamls+=("scc")
 oc_yamls+=("volumereplicationclass")
 oc_yamls+=("volumesnapshotclass")
 oc_yamls+=("volumesnapshotcontent")
+oc_yamls+=("volumegroupsnapshotclass")
+oc_yamls+=("volumegroupsnapshotcontent")
 
 # collect describe output of OC commands
 commands_desc=()
@@ -52,6 +56,8 @@ commands_desc+=("scc")
 commands_desc+=("volumereplicationclass")
 commands_desc+=("volumesnapshotclass")
 commands_desc+=("volumesnapshotcontent")
+commands_desc+=("volumegroupsnapshotclass")
+commands_desc+=("volumegroupsnapshotcontent")
 
 # collection path for OC commands
 mkdir -p "${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/"

--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -136,6 +136,12 @@ dbglog "collecting dump of oc get volumesnapshot all namespaces"
 { oc describe volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
 { oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" volumesnapshot 2>&1; } | dbglog
 
+# For volumegroupsnapshot of all namespaces
+dbglog "collecting dump of oc get volumegroupsnapshot all namespaces"
+{ oc get volumegroupsnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumegroupsnapshot_all_namespaces"
+{ oc describe volumegroupsnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumegroupsnapshot_all_namespaces"
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" volumegroupsnapshot 2>&1; } | dbglog
+
 # For obc of all namespaces
 dbglog "collecting dump of oc get obc all namespaces"
 { oc get obc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"


### PR DESCRIPTION
adding the support to connect below objects

* volumegroupsnapshot
* volumegroupsnapshotcontent
* volumegroupsnapshotclass

cc @yati1998 , "Will there be any issues if the Custom Resource Definitions (CRDs) are not installed? I assume that the CRDs will be installed in OpenShift Container Platform (OCP) 4.16. However, I want to ensure that nothing breaks due to the absence of CRDs. Do we need to perform any additional checks to confirm the presence of CRDs?"