### PR TITLE
Fix error in expansion of SINCE_TIME

### DIFF
--- a/collection-scripts/gather_ceph_resources
+++ b/collection-scripts/gather_ceph_resources
@@ -85,7 +85,7 @@ rados_commands+=("rados ls --pool=ocs-storagecluster-cephfilesystem-metadata --n
 # Inspecting ceph related custom resources for all namespaces
 for resource in "${ceph_resources[@]}"; do
     dbglog "collecting dump ${resource}"
-    { oc adm inspect --dest-dir="${CEPH_COLLECTION_PATH}" --all-namespaces "${resource}" 2>&1; } | dbglog
+    { oc adm inspect --dest-dir="${CEPH_COLLECTION_PATH}" --all-namespaces ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${resource}" 2>&1; } | dbglog
 done
 
 namespaces=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)

--- a/collection-scripts/gather_clusterscoped_resources
+++ b/collection-scripts/gather_clusterscoped_resources
@@ -72,7 +72,7 @@ done
 
 # Run the Collection of Resources oc yaml to list
 for oc_yaml in "${oc_yamls[@]}"; do
-    { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${oc_yaml}" 2>&1; } | dbglog
+    { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${oc_yaml}" 2>&1; } | dbglog
 done
 
 # Run the Collection of Resources oc describe to list

--- a/collection-scripts/gather_common_ceph_resources
+++ b/collection-scripts/gather_common_ceph_resources
@@ -14,5 +14,5 @@ common_ceph_resources+=(cephclusters)
 
 for resource in "${common_ceph_resources[@]}"; do
     dbglog "collecting dump ${resource}"
-    { oc adm inspect --dest-dir="${CEPH_COLLECTION_PATH}" --all-namespaces "${resource}" 2>&1; } | dbglog
+    { oc adm inspect --dest-dir="${CEPH_COLLECTION_PATH}" --all-namespaces ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${resource}" 2>&1; } | dbglog
 done

--- a/collection-scripts/gather_dr_resources
+++ b/collection-scripts/gather_dr_resources
@@ -28,7 +28,7 @@ dr_resources+=(configmap)
 dr_resources+=(pods -owide)
 
 dbglog "collecting dump of openshift-dr-system namespace"
-{ oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ns/"${NAMESPACE}" 2>&1; } | dbglog
+{ oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} ns/"${NAMESPACE}" 2>&1; } | dbglog
 
 # Create the dir for oc_output for openshift-dr-system namespace
 mkdir -p "${BASE_COLLECTION_PATH}/namespaces/${NAMESPACE}/oc_output/"

--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -76,11 +76,11 @@ oc_yamls+=("alertmanagerconfig")
 
 for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_NAMESPACE $OPERATOR_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      dbglog "collecting dump of clusterresourceversion"
      for oc_yaml in "${oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${oc_yaml}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -122,40 +122,40 @@ mkdir -p "${BASE_COLLECTION_PATH}/namespaces/all/"
 # Run the Collection of Resources using must-gather
 for resource in "${resources[@]}"; do
      dbglog "collecting dump of ${resource}"
-     { oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" "${resource}" 2>&1; } | dbglog
+     { oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${resource}" 2>&1; } | dbglog
 done
 
 # For pvc of all namespaces
 dbglog "collecting dump of oc get pvc all namespaces"
 { oc get pvc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" pvc 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} pvc 2>&1; } | dbglog
 
 # For volumesnapshot of all namespaces
 dbglog "collecting dump of oc get volumesnapshot all namespaces"
 { oc get volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
 { oc describe volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" volumesnapshot 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} volumesnapshot 2>&1; } | dbglog
 
 # For volumegroupsnapshot of all namespaces
 dbglog "collecting dump of oc get volumegroupsnapshot all namespaces"
 { oc get volumegroupsnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumegroupsnapshot_all_namespaces"
 { oc describe volumegroupsnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumegroupsnapshot_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" volumegroupsnapshot 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} volumegroupsnapshot 2>&1; } | dbglog
 
 # For obc of all namespaces
 dbglog "collecting dump of oc get obc all namespaces"
 { oc get obc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" obc 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} obc 2>&1; } | dbglog
 
 # For VolumeReplication of all namespaces
 dbglog "collecting dump of oc get volumereplication all namespaces"
 { oc get volumereplication --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vr_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" volumereplication 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} volumereplication 2>&1; } | dbglog
 
 # For VolumeReplicationGroups of all namespaces
 dbglog "collecting dump of oc get volumereplicationgroups all namespaces"
 { oc get volumereplicationgroups --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/vrg_all_namespaces"
-{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" "${LOG_FILTER_ARGS}" vrg 2>&1; } | dbglog
+{ oc adm inspect --all-namespaces --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} vrg 2>&1; } | dbglog
 
 # Collect details of storageclassclaim of all namespaces for managed services
 dbglog "collecting dump of oc get storageclassclaim all namespaces"

--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -47,7 +47,7 @@ noobaa diagnose --dir "${NOOBAA_COLLLECTION_PATH}"/raw_output/ --namespace opens
 # Run the Collection of NooBaa Resources using must-gather
 for resource in "${noobaa_resources[@]}"; do
     dbglog "collecting dump of ${resource}"
-    { oc adm inspect --all-namespaces --dest-dir="${NOOBAA_COLLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${resource}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { oc adm inspect --all-namespaces --dest-dir="${NOOBAA_COLLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${resource}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Collect logs for all noobaa pods using oc logs

--- a/collection-scripts/gather_odf_client
+++ b/collection-scripts/gather_odf_client
@@ -53,11 +53,11 @@ client_commands_desc+=("storageclassclaims")
 
 for INSTALL_NAMESPACE in $CLIENT_OPERATOR_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      # Run the Collection of oc yaml outputs
      for oc_yaml in "${oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${oc_yaml}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output
@@ -82,11 +82,11 @@ done
 
 for INSTALL_NAMESPACE in $STORAGE_CLIENT_NAMESPACE; do
      dbglog "collecting dump of namespace ${INSTALL_NAMESPACE}"
-     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
+     { oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} ns/"${INSTALL_NAMESPACE}" 2>&1; } | dbglog
      # Run the Collection of oc yaml outputs
      for oc_yaml in "${client_oc_yamls[@]}"; do
           # shellcheck disable=SC2129
-          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" "${LOG_FILTER_ARGS}" "${oc_yaml}" 2>&1; } | dbglog
+          { oc adm inspect -n "${INSTALL_NAMESPACE}" --dest-dir="${BASE_COLLECTION_PATH}" ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${oc_yaml}" 2>&1; } | dbglog
      done
 
      # Create the dir for oc_output


### PR DESCRIPTION
In cases where `LOG_FILTER_ARGS` was unset/empty, an empty string was interpreted by bash breaking the oc commands.

This patch addresses the issue by expanding only when the value is set. If unset, an empty space is used instead of empty string. ` ` instead of `' '`.

Regards