### PR TITLE
Negate overlapping args with `-o` flag

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -170,25 +170,25 @@ if [ "$noobaa" == true ]; then
     pids+=($!)
 fi
 
-if [ "$ceph" == true ]; then
+if [ "$ceph" == true ] && [ "$odf" == false ]; then
     echo "Collect ceph pod logs..."
     gather_ceph_pod_logs &
     pids+=($!)
 fi
 
-if [ "$cephlogs" == true ]; then
+if [ "$cephlogs" == true ] && [ "$odf" == false ]; then
     echo "Collect ceph daemon logs..."
     gather_ceph_logs ${BASE_COLLECTION_PATH} &
     pids+=($!)
 fi
 
-if [ "$namespaced" == true ]; then
+if [ "$namespaced" == true ] && [ "$odf" == false ]; then
     echo "Collect namespaced logs..."
     gather_namespaced_resources ${BASE_COLLECTION_PATH} &
     pids+=($!)
 fi
 
-if [ "$clusterscoped" == true ]; then
+if [ "$clusterscoped" == true ] && [ "$odf" == false ]; then
     echo "Collect clusterscoped logs..."
     gather_clusterscoped_resources ${BASE_COLLECTION_PATH} &
     pids+=($!)


### PR DESCRIPTION
Fixes: #137

Right now if someone runs must-gather in odf mode
by using `-o` or `--odf` flag and also issues one
of `-c`, `-cl`, `-ns` or `-cs`, these scripts will be executed twice,
adding to the collection time and creating redundant collection.

This patch prevents execution of any of the sub-scripts that are already called by `-o` flag.