### PR TITLE
Fix GH action failing due to typo

### DIFF
--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -20,7 +20,7 @@ resources=()
 # resources+=(storageclusters)
 # resources+=(storagesystem)
 
-# collect OB/OBC resoureces
+# collect OB/OBC resources
 resources+=(objectbuckets)
 
 # collection path for OC commands


### PR DESCRIPTION
There was a typo in one of the sub-scripts which lead to failing GH Action runs. This patch fixes the same.