### PR TITLE
Include pod metadata in must-gather output

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -132,6 +132,9 @@ START_TIME=$(date +%r)
 start=$(date +%s)
 dbglog "collection started at: ${START_TIME}"
 
+# Print and export must-gather pod details
+export_pod_image_details
+
 if [ -n "${LOG_FILTER_ARGS:-}" ]; then
     dbglog "Logs will be filtered using: ${LOG_FILTER_ARGS}"
 fi


### PR DESCRIPTION
This PR adds support of fetching the pod metadata
using the kubernetes API.

An additional pod-metadata.json file is created in the report with the dump of entire metadata for the pod.

A much simpler debug log stating the image version being used is printed to the console as well.

The image details are printed to console like:
```
[must-gather      ] OUT 2024-08-07T15:21:19.386616439Z namespace/openshift-must-gather-8452x created
[must-gather      ] OUT 2024-08-07T15:21:19.39445305Z clusterrolebinding.rbac.authorization.k8s.io/must-gather-jkbhm created
[must-gather      ] OUT 2024-08-07T15:21:19.429835897Z pod for plug-in image quay.io/niryadav/odf-must-gather:infot7 created
[must-gather-2d5hn] POD 2024-08-07T15:21:26.932423529Z volume percentage checker started.....
[must-gather-2d5hn] POD 2024-08-07T15:21:26.968008955Z volume usage percentage 0
[must-gather-2d5hn] POD 2024-08-07T15:21:27.126271465Z must-gather is using image: quay.io/niryadav/odf-must-gather:infot7 <==========================
```
Since we are fetching the pod details we can also have a JSON file say pod-metadata.json which will be a JSON dump of `kubectl get pod <mg-pod>`

```
❯ cat gather-debug.log | grep image
must-gather is using image: quay.io/niryadav/odf-must-gather:infot7

❯ cat pod-metadata.json | grep -o '"image": "[^"]*"' | head -n 1
"image": "quay.io/niryadav/odf-must-gather:infot7"
```

This feature is requested by [BZ: 2290500](https://bugzilla.redhat.com/show_bug.cgi?id=2290500)

Regards