### PR TITLE
Update ImagePullPolicy to Always

### DIFF
--- a/templates/pod.template
+++ b/templates/pod.template
@@ -29,7 +29,7 @@ spec:
           name: rook-ceph-mon
           key: ceph-secret
     image: IMAGE_NAME
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
     name: must-gather-helper
     securityContext:
       privileged: true


### PR DESCRIPTION
This PR updates the ImagePullPolicy for the must-gather pod to Always.

This adds value to the development phase where one can just delete the pod and have an updated one with the latest image.

Prior to this one had to use different tags for each test which was not ideal.

Note: This would not increase pod deploy timinigs in prod env as we do not update the prod image that often and ImagePullPolicy of always first checks the SHA sum from registry against local cache.

If the image is cached locally, it is not pulled again.