### PR TITLE
Bug 2308101: logrotate: add logrotate functionality for csi operator

### DIFF
--- a/collection-scripts/gather_ceph_logs
+++ b/collection-scripts/gather_ceph_logs
@@ -73,6 +73,7 @@ CMDS
         mkdir -p "${COREDUMP_OUTPUT_DIR}"
         ceph_daemon_log_collection &
         csi_log_collection &
+        csi_operator_log_collection &
         pids_log+=($!)
         crash_core_collection &
         pids_log+=($!)


### PR DESCRIPTION
currently client operator has started using csi operator so collecting the csi logs from a new host path
hat csi-operator supports