### PR TITLE
Bug 2308101: logrotate: add logrotate functionality for csi operator 

### DIFF
--- a/collection-scripts/gather_ceph_logs
+++ b/collection-scripts/gather_ceph_logs
@@ -73,6 +73,7 @@ CMDS
         mkdir -p "${COREDUMP_OUTPUT_DIR}"
         ceph_daemon_log_collection &
         csi_log_collection &
+        csi_operator_log_collection &
         pids_log+=($!)
         crash_core_collection &
         pids_log+=($!)

--- a/collection-scripts/gather_ceph_logs
+++ b/collection-scripts/gather_ceph_logs
@@ -27,6 +27,12 @@ for ns in $namespaces; do
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}-debug" | awk '{print $1}')":/host/var/lib/rook/"${ns}".nfs.csi.ceph.com/log "${CSI_LOG_OUTPUT_DIR}"
     }
 
+    # collect logs from the csi pods if csi is installed using csi-operator
+    csi_operator_log_collection() {
+        dbglog "collecting csi logs from node ${node}"
+        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}-debug" | awk '{print $1}')":/host/var/lib/cephcsi "${CSI_LOG_OUTPUT_DIR}"
+    }
+
     crash_core_collection() {
         dbglog "collecting crash core dump from node ${node}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/rook/"${ns}"/crash/ "${CRASH_OUTPUT_DIR}"


### PR DESCRIPTION
currently client operator has started using csi operator
so collecting the csi logs from a new host path
hat csi-operator supports

Signed-off-by: parth-gr <partharora1010@gmail.com>
(cherry picked from commit https://github.com/red-hat-storage/odf-must-gather/commit/799c77a94ae2c61e732f4f8cb031555c310cfc4b)