### PR TITLE
Add missing PIDs while collecting ceph logs

### DIFF
--- a/collection-scripts/gather_ceph_logs
+++ b/collection-scripts/gather_ceph_logs
@@ -72,7 +72,9 @@ CMDS
         mkdir -p "${KERNEL_OUTPUT_DIR}"
         mkdir -p "${COREDUMP_OUTPUT_DIR}"
         ceph_daemon_log_collection &
+        pids_log+=($!)
         csi_log_collection &
+        pids_log+=($!)
         csi_operator_log_collection &
         pids_log+=($!)
         crash_core_collection &


### PR DESCRIPTION
This PR adds the missing PIDs for subprocesses
while collecting ceph logs.