### PR TITLE
Add new flag to collect minimal resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -11,6 +11,7 @@ namespaced=false
 clusterscoped=false
 help=false
 default=true
+minimal=false
 
 # Store PIDs of all the subprocesses
 pids=()
@@ -57,6 +58,11 @@ while [[ $# -gt 0 ]]; do
         default=false
         shift
         ;;
+    -m | --minimal)
+        minimal=true
+        default=false
+        shift
+        ;;
     -h | --help)
         help=true
         default=false
@@ -93,6 +99,7 @@ Options:
   -cl, --ceph-logs          Collect ceph daemon, kernel, journal logs and crash reports
   -ns, --namespaced         Collect namespaced resources
   -cs, --clusterscoped      Collect clusterscoped resources
+  -m,  --minimal            Collect storagecluster, cephcluster CRDs and operator CSVs
   -h,  --help               Print this help message
 
 Description:
@@ -194,6 +201,12 @@ fi
 if [ "$clusterscoped" == true ] && [ "$odf" == false ]; then
     echo "Collect clusterscoped logs..."
     gather_clusterscoped_resources ${BASE_COLLECTION_PATH} &
+    pids+=($!)
+fi
+
+if [ "$minimal" == true ]; then
+    echo "Collect minimal resource files..."
+    gather_minimal_resources ${BASE_COLLECTION_PATH} &
     pids+=($!)
 fi
 

--- a/collection-scripts/gather_minimal_resources
+++ b/collection-scripts/gather_minimal_resources
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
+
+MINIMAL_COLLECTION_PATH="${BASE_COLLECTION_PATH}/minimal_resources"
+
+# Create directories for minimal resources collection
+mkdir -p "${MINIMAL_COLLECTION_PATH}/oc_output"
+
+# Define minimal resources
+minimal_resources=()
+minimal_resources+=(cephclusters)
+minimal_resources+=(cephblockpools)
+minimal_resources+=(cephfilesystems)
+minimal_resources+=(csv)
+minimal_resources+=(sc)
+minimal_resources+=(configmaps)
+
+# Collect resources except for storageclusters
+for resource in "${minimal_resources[@]}"; do
+    dbglog "collecting dump ${resource}"
+    { oc adm inspect --dest-dir="${MINIMAL_COLLECTION_PATH}" --all-namespaces ${LOG_FILTER_ARGS:+"${LOG_FILTER_ARGS}"} "${resource}" 2>&1; } | dbglog
+done
+
+# Special handling for storageclusters
+dbglog "Collecting storageclusters"
+{ oc get storageclusters --all-namespaces -o yaml; } > "${MINIMAL_COLLECTION_PATH}/oc_output/storageclusters.yaml" 2>&1
+
+# Final message indicating completion
+dbglog "Minimal resources collection completed."


### PR DESCRIPTION
Creating a flag to limit data collection to only major CRDs and CSVs, reducing time taken and log clutter.
It collects minimum required data and have kept the alignment similar to other flags for streamlined parsing.