### PR TITLE
gather: Fix rsync of files from the must-gather pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM registry.ci.openshift.org/ocp/4.17:cli
 
-WORKDIR /tmp
+WORKDIR /usr/bin
+COPY collection-scripts .
 
-COPY . .
-
-RUN mkdir -p /templates
-
-COPY collection-scripts/* /usr/bin/
-COPY templates/* /templates/
+WORKDIR /
+COPY templates ./templates
 
 # We do not need it as of now
 # jq is not preinstalled on openshift/origin-cli either


### PR DESCRIPTION
OC cli expects the collection of a must-gather to be inside `/must-gather` by default. See
[here](https://github.com/openshift/oc/blob/5110357c067c5933e75604504f1521927ccaaf27/pkg/cli/admin/mustgather/mustgather.go#L143C22-L143C35)

This patch also addresses an issue where all the files present in the cwd of user building must-gather would be copied into the image. Which was not ideal and might include personal files.