### PR TITLE
Change cli option minimal-crds

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -58,7 +58,7 @@ while [[ $# -gt 0 ]]; do
         default=false
         shift
         ;;
-    -m | --minimal)
+    -m | --minimal-crds)
         minimal=true
         default=false
         shift
@@ -99,7 +99,7 @@ Options:
   -cl, --ceph-logs          Collect ceph daemon, kernel, journal logs and crash reports
   -ns, --namespaced         Collect namespaced resources
   -cs, --clusterscoped      Collect clusterscoped resources
-  -m,  --minimal            Collect storagecluster, cephcluster CRDs and operator CSVs
+  -m,  --minimal-crds       Collect storagecluster, cephcluster CRDs and operator CSVs
   -h,  --help               Print this help message
 
 Description:


### PR DESCRIPTION
This PR fixes an inconsistency between the design documentation and the codebase regarding a flag name.

Issue:
The design document specifies the flag name as `--minimal-crds`, while the implementation in the code uses `--minimal`.

Fix: 
Updated the flag name in the code from `--minimal` to `--minimal-crds` to align with the design documentation.
This change ensures consistency between the design document and the implementation, improving clarity for users and maintainers.