### PR TITLE
gather: Fix removal of empty files from gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -243,8 +243,8 @@ totalTime=$((end - start))
 {
     printf "total time taken by collection was %s seconds \n" ${totalTime}
     printf "collection ended at: %s \n" "${END_TIME}"
-    echo "deleting empty files"
+    echo "deleting empty files..."
 
 } >>${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
-find "${BASE_COLLECTION_PATH}" -empty -delete >>${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
+find "${BASE_COLLECTION_PATH}" -type f \( -empty -o -size 1c \) -print -delete >>${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
 exit 0


### PR DESCRIPTION
The MG currently uses `-empty` with find to remove the empty files. This only works for files with a
size of 0 bytes.

In cases where the file has an empty line or a single character this doesn't work.

This patch updates the logic to also consider files with LF endings (just a new line)