### PR TITLE
ceph: Collect CephBlockPoolRadosNamespace(s) in external deployments

### DIFF
--- a/collection-scripts/gather_common_ceph_resources
+++ b/collection-scripts/gather_common_ceph_resources
@@ -11,6 +11,7 @@ common_ceph_resources=()
 common_ceph_resources+=(cephobjectstores)
 common_ceph_resources+=(cephobjectstoreusers)
 common_ceph_resources+=(cephclusters)
+common_ceph_resources+=(cephblockpoolradosnamespaces.ceph.rook.io)
 
 for resource in "${common_ceph_resources[@]}"; do
     dbglog "collecting dump ${resource}"


### PR DESCRIPTION
This patch adds support for collection of CephBlockPoolRadosNamespaces in external mode deployments.