### PR TITLE
Fix noobaa collection

### DIFF
--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -27,7 +27,14 @@ noobaa_desc=()
 noobaa_desc+=("pod noobaa-db-pg-0")
 noobaa_desc+=("statefulset.apps noobaa-db-pg")
 
-/templates/noobaa.template
+cp_noobaa_cli "$INSTALL_NAMESPACE"
+
+# Bail out early if noobaa CLI is not present
+if [ ! -f /usr/bin/noobaa ]; then
+  echo "FATAL: failed to locate noobaa CLI"
+
+  exit 1
+fi
 
 mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/}"
 

--- a/collection-scripts/utils.sh
+++ b/collection-scripts/utils.sh
@@ -105,8 +105,30 @@ function export_pod_image_details() {
     dbglog "must-gather is using image: $IMAGE"
 }
 
+# cp_nooba_cli copies the nooba CLI from noobaa-operator pod
+# it requires the install namespace of odf-operator to work
+function cp_noobaa_cli() {
+  if [ -z "$1" ]; then
+    echo "Please provide install namespace"
+    exit 1
+  fi
+
+  local pod_name="$(oc get pods -n "$1" | grep noobaa-operator | awk '{ print $1 }')"
+  if [ -z "$pod_name" ]; then
+    echo "failed to find noooba operator pod in namespace $1"
+  else
+    oc -n "$1" rsync "$pod_name":/usr/local/bin/noobaa-operator /tmp
+
+    mv /tmp/noobaa-operator /usr/bin/noobaa
+    chmod +x /usr/bin/noobaa
+
+    echo "successfully copied noobaa CLI to must-gather pod"
+  fi
+}
+
 # Export the functions so that the file needs to be sourced only once
 export -f dbglog
 export -f dbglogf
 export -f parse_since_time
 export -f export_pod_image_details
+export -f cp_noobaa_cli

--- a/templates/noobaa.template
+++ b/templates/noobaa.template
@@ -1,7 +1,0 @@
-pod=$(oc get pods -n openshift-storage| grep noobaa-operator|  awk '{print $1}')
-if [ -z  $pod ]; then
-   echo "noobaa operator pod does not exist"
-else
-   oc rsync -n  openshift-storage $pod:/usr/local/bin/noobaa-operator /usr/bin
-   mv /usr/bin/noobaa-operator /usr/bin/noobaa
-fi


### PR DESCRIPTION
This script fixes an issue where noobaa diagnostics were not collected due to missing noobaa CLI.

If noobaa collection is requested and must-gather fails to locate the CLI, it is treated as a fatal error and further noobaa collection is aborted.