### PR TITLE
Add emptyDir volume mount for /etc/ceph to allow write access in helper pod

### DIFF
--- a/templates/pod.template
+++ b/templates/pod.template
@@ -37,6 +37,8 @@ spec:
       runAsUser: 2016
       runAsGroup: 2016
     volumeMounts:
+      - mountPath: /etc/ceph
+        name: ceph-config
       - mountPath: /dev
         name: dev
       - mountPath: /sys/bus
@@ -61,3 +63,5 @@ spec:
         items:
         - key: data
           path: mon-endpoints
+    - name: ceph-config
+      emptyDir: {}


### PR DESCRIPTION
Fixes an issue where the must-gather toolbox pod fails with a read-only filesystem error when writing to `/etc/ceph/ceph.conf` and `/etc/ceph/keyring`

