### PR TITLE
collect cnpg cluster info in gather_noobaa_resources

### DIFF
--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -24,10 +24,15 @@ noobaa_cli+=("status")
 noobaa_cli+=("obc list")
 
 noobaa_desc=()
-noobaa_desc+=("pod noobaa-db-pg-0")
+# keeping desc for old noobaa-db-pg statefulset to debug upgrade issues
 noobaa_desc+=("statefulset.apps noobaa-db-pg")
+noobaa_desc+=("pod noobaa-db-pg-0")
+noobaa_desc+=("pod noobaa-db-pg-cluster-1")
+noobaa_desc+=("pod noobaa-db-pg-cluster-2")
+noobaa_desc+=("clusters.postgresql.cnpg.noobaa.io noobaa-db-pg-cluster")
 
 cp_noobaa_cli "$INSTALL_NAMESPACE"
+cp_cnpg_cli "$INSTALL_NAMESPACE"
 
 # Bail out early if noobaa CLI is not present
 if [ ! -f /usr/bin/noobaa ]; then
@@ -41,6 +46,31 @@ mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/}"
 # Save the information of all Postgres DBs in the NooBaa DB pod
 dbglog "Collecting MCG database information..."
 oc rsh --namespace "${INSTALL_NAMESPACE}" noobaa-db-pg-0 psql -d nbcore -c '\pset pager off' -c '\list+' -c '\dt+' &>"${NOOBAA_COLLLECTION_PATH}"/raw_output/db_list.txt 2>&1
+
+dbglog "Collecting CNPG cluster information..."
+mkdir -p "${NOOBAA_COLLLECTION_PATH}/cnpg_info/"
+# Get the status of the CNPG cluster
+oc cnpg -n "${INSTALL_NAMESPACE}" status noobaa-db-pg-cluster -vv &>"${NOOBAA_COLLLECTION_PATH}"/cnpg_info/cnpg_cluster_status.txt 2>&1
+# Get the list of databases and tables 
+oc rsh --namespace "${INSTALL_NAMESPACE}" svc/noobaa-db-pg-cluster-rw psql -d nbcore -c '\pset pager off' -c '\list+' -c '\dt+' &>"${NOOBAA_COLLLECTION_PATH}"/raw_output/db_list.txt 2>&1
+# Get from the pg_stat_statements table the top 20 queries by total execution time. get the tables from both pods
+pg_stat_statement_query="SELECT 
+  substring(query, 1, 100) AS short_query,
+  round(total_exec_time::numeric, 2) AS total_exec_time,
+  calls,
+  round(mean_exec_time::numeric, 2) AS mean,
+  round((100 * total_exec_time / sum(total_exec_time::numeric) OVER ())::numeric, 2) AS percentage_cpu 
+FROM pg_stat_statements 
+ORDER BY total_exec_time DESC 
+LIMIT 20;"
+oc rsh --namespace "${INSTALL_NAMESPACE}" pod/noobaa-db-pg-cluster-1 psql -d nbcore -c '\pset pager off' -c "${pg_stat_statement_query}" &>"${NOOBAA_COLLLECTION_PATH}"/cnpg_info/pg_stat_statements-noobaa-db-pg-cluster-1.txt 2>&1
+oc rsh --namespace "${INSTALL_NAMESPACE}" pod/noobaa-db-pg-cluster-2 psql -d nbcore -c '\pset pager off' -c "${pg_stat_statement_query}" &>"${NOOBAA_COLLLECTION_PATH}"/cnpg_info/pg_stat_statements-noobaa-db-pg-cluster-2.txt 2>&1
+# Get the full pg_stat_statements table by descending order of total execution time
+oc rsh --namespace "${INSTALL_NAMESPACE}" pod/noobaa-db-pg-cluster-1 psql -d nbcore -c '\pset pager off' -c 'SELECT * FROM pg_stat_statements ORDER BY total_exec_time DESC;' &>>"${NOOBAA_COLLLECTION_PATH}"/cnpg_info/pg_stat_statements-noobaa-db-pg-cluster-1.txt 2>&1
+oc rsh --namespace "${INSTALL_NAMESPACE}" pod/noobaa-db-pg-cluster-2 psql -d nbcore -c '\pset pager off' -c 'SELECT * FROM pg_stat_statements ORDER BY total_exec_time DESC;' &>>"${NOOBAA_COLLLECTION_PATH}"/cnpg_info/pg_stat_statements-noobaa-db-pg-cluster-2.txt 2>&1
+# Get the operator and cluster reports
+oc cnpg -n "${INSTALL_NAMESPACE}" report operator -l -t -f "${NOOBAA_COLLLECTION_PATH}"/cnpg_info/cnpg_operator_report.zip 2>&1 
+oc cnpg -n "${INSTALL_NAMESPACE}" report cluster noobaa-db-pg-cluster -l -t -f "${NOOBAA_COLLLECTION_PATH}"/cnpg_info/cnpg_cluster_report.zip 2>&1 
 
 # Run the Collection of Noobaa cli using must-gather
 # shellcheck disable=SC2086

--- a/collection-scripts/utils.sh
+++ b/collection-scripts/utils.sh
@@ -126,9 +126,31 @@ function cp_noobaa_cli() {
   fi
 }
 
+# cp_cnpg_cli copies the cnpg CLI from cnpg operator pod
+# it requires the install namespace of odf-operator to work
+function cp_cnpg_cli() {
+  if [ -z "$1" ]; then
+    echo "Please provide install namespace"
+    exit 1
+  fi
+
+  local pod_name="$(oc get pods -n "$1" | grep cnpg-controller-manager | awk '{ print $1 }')"
+  if [ -z "$pod_name" ]; then
+    echo "failed to find cnpg operator pod in namespace $1"
+  else
+    oc -n "$1" rsync "$pod_name":/usr/bin/kubectl-cnpg /tmp
+
+    mv /tmp/kubectl-cnpg /usr/bin/kubectl-cnpg
+    chmod +x /usr/bin/kubectl-cnpg
+
+    echo "successfully copied cnpg CLI to must-gather pod"
+  fi
+}
+
 # Export the functions so that the file needs to be sourced only once
 export -f dbglog
 export -f dbglogf
 export -f parse_since_time
 export -f export_pod_image_details
 export -f cp_noobaa_cli
+export -f cp_cnpg_cli


### PR DESCRIPTION
For 4.19 CNPG integration in noobaa - added collection of cnpg information in `gather_noobaa_resources` script
collecting the following information:
* `describe` output for the new cluster pods. Keeping the description of older resources on purpose, for upgrade issues. 
* Using the CNPG CLI (copied from the cnpg operator pod), get the status and reports for the operator and the cluster
* Get `pg_stat_statements` statistics, which are now collected by default.