### PR TITLE
error collecting pod details

### DIFF
--- a/collection-scripts/gather_dr_resources
+++ b/collection-scripts/gather_dr_resources
@@ -29,7 +29,7 @@ fi
 dr_resources=()
 dr_resources+=(secrets)
 dr_resources+=(configmap)
-dr_resources+=(pods -owide)
+dr_resources+=("pods -o wide")
 
 
 # Iterate through dr namespaces


### PR DESCRIPTION
in case of dr collection we collect pods -owide
as dr resource, but must-gather takes pods and -owide as different resources, resulting in error.
`collecting oc command -owide
You must specify the type of resource to get.
Use "oc api-resources" for a complete list of
supported resources.`