### PR TITLE
remove unused oc_output directory creation in must-gather

### DIFF
--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -23,9 +23,6 @@ resources=()
 # collect OB/OBC resources
 resources+=(objectbuckets)
 
-# collection path for OC commands
-mkdir -p "${BASE_COLLECTION_PATH}/oc_output/"
-
 # Command List
 commands_get=()
 


### PR DESCRIPTION
This pr removes the creation of the `${BASE_COLLECTION_PATH}/oc_output/` directory in the must-gather script. 
The directory is not used and remains empty, so deleting it helps clean up the script.

Fixes: #274 