### PR TITLE
Collect PrometheusRules from relevant namespace

### DIFF
--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -44,6 +44,7 @@ commands_get+=("storagerequest")
 commands_get+=("alertmanager")
 commands_get+=("alertmanagerconfig")
 commands_get+=("prometheus")
+commands_get+=("prometheusrules")
 commands_get+=("cephfilesystemsubvolumegroups.ceph.rook.io")
 
 # collect oc output of OC desc commands
@@ -58,6 +59,7 @@ commands_desc+=("storageprofiles")
 commands_desc+=("storagerequest")
 commands_desc+=("alertmanager")
 commands_desc+=("prometheus")
+commands_desc+=("prometheusrules")
 commands_desc+=("alertmanagerconfig")
 commands_desc+=("cephfilesystemsubvolumegroups.ceph.rook.io")
 
@@ -71,6 +73,7 @@ oc_yamls+=("operatorconditions")
 oc_yamls+=("storagerequest")
 oc_yamls+=("alertmanager")
 oc_yamls+=("prometheus")
+oc_yamls+=("prometheusrules")
 oc_yamls+=("alertmanagerconfig")
 oc_yamls+=("recipe")
 


### PR DESCRIPTION
Adds support for collecting PrometheusRule resources

- Included in `oc get`, `oc describe`, and `oc get -o yaml` command sets
- Captures rules from relevant namespaces such as openshift-storage