### PR TITLE
fix: remove extra '}' from mkdir path in NooBaa collection

### DIFF
--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -41,7 +41,7 @@ if [ ! -f /usr/bin/noobaa ]; then
   exit 1
 fi
 
-mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/}"
+mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/"
 
 # Save the information of all Postgres DBs in the NooBaa DB pod
 dbglog "Collecting MCG database information..."


### PR DESCRIPTION
Remove extra `}` from:

```
mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/}"
```
This fixes the path so it correctly creates `/noobaa/raw_output/` without generating an unintended `}/` folder.

Fixes: #282 