### PR TITLE
remove storagesystem CR from collection

### DIFF
--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -18,7 +18,6 @@ resources=()
 
 # TODO: Re enable the collection of storagecluster via inspect command
 # resources+=(storageclusters)
-# resources+=(storagesystem)
 
 # collect OB/OBC resources
 resources+=(objectbuckets)
@@ -53,7 +52,6 @@ commands_desc+=("pods")
 commands_desc+=("hpa")
 commands_desc+=("subscription")
 commands_desc+=("storagecluster")
-commands_desc+=("storagesystem")
 commands_desc+=("storageconsumer")
 commands_desc+=("storageprofiles")
 commands_desc+=("storagerequest")
@@ -137,7 +135,6 @@ for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_
      done
      # NOTE: This is a temporary fix for collecting the storagecluster as we are not able to collect the storagecluster using the inspect command
      { oc get storageclusters.ocs.openshift.io -n "${INSTALL_NAMESPACE}" -o yaml; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/storagecluster.yaml" 2>&1
-     { oc get storagesystem -n "${INSTALL_NAMESPACE}" -o yaml; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/storagesystem.yaml" 2>&1
      { oc get storageconsumer -n "${INSTALL_NAMESPACE}" -o yaml; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/storageconsumer.yaml" 2>&1
      { oc get secret rook-ceph-external-cluster-details -n "${INSTALL_NAMESPACE}" -o jsonpath='{.data.external_cluster_details}' | base64 --decode | sed -E 's/("\w+Key":\s*)"[A-Za-z0-9+/=]+"/\1"REDACTED"/g'; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/external_cluster_details.json" 2>&1
 done


### PR DESCRIPTION
This commit removes the storagesystem CR as
it has been removed from ODF4.19 onwards.