### PR TITLE
DFBUGS-4217: [release-4.15]-remove core dump collection 

### DIFF
--- a/collection-scripts/gather_ceph_logs
+++ b/collection-scripts/gather_ceph_logs
@@ -17,10 +17,9 @@ for ns in $namespaces; do
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}-debug" | awk '{print $1}')":/host/var/lib/rook/"${ns}"/log "${CEPH_DAEMON_LOG_OUTPUT_DIR}"
     }
 
-    crash_core_collection() {
+    crash_collection() {
         dbglog "collecting crash core dump from node ${node}"
         oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/rook/"${ns}"/crash/ "${CRASH_OUTPUT_DIR}"
-        oc rsync -n "${ns}" "$(oc get pods -n "${ns}" --no-headers | grep "${node//./}"-debug | awk '{print $1}')":/host/var/lib/systemd/coredump/ "${COREDUMP_OUTPUT_DIR}"
     }
 
     journal_collection() {
@@ -47,17 +46,15 @@ CMDS
         CEPH_DAEMON_LOG_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/ceph_daemon_log_${node}
         JOURNAL_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/journal_${node}
         KERNEL_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/kernel_${node}
-        COREDUMP_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/coredump_${node}
-        mkdir -p "${CRASH_OUTPUT_DIR}"
         mkdir -p "${CEPH_DAEMON_LOG_OUTPUT_DIR}"
         mkdir -p "${JOURNAL_OUTPUT_DIR}"
         mkdir -p "${KERNEL_OUTPUT_DIR}"
-        mkdir -p "${COREDUMP_OUTPUT_DIR}"
+        mkdir -p "${CRASH_OUTPUT_DIR}"
         ceph_daemon_log_collection &
         pids_log+=($!)
-        crash_core_collection &
-        pids_log+=($!)
         journal_collection &
+        pids_log+=($!)
+        crash_collection &
         pids_log+=($!)
         if [ -n "${pids_log[*]}" ]; then
             # wait for all pids
@@ -74,5 +71,5 @@ CMDS
 CMDS
     done
 
-    dbglog "ceph core dump collection completed"
+    dbglog "ceph logs collection completed"
 done


### PR DESCRIPTION
As per request this commit removes the
core dump collection to avoid
heavy files collection which is not required.

This is a manual cherry-pick of https://github.com/red-hat-storage/odf-must-gather/pull/248