### PR TITLE
DFBUGS-5720: use ocs-storagecluster.ocs.openshift.io to collect resources

### DIFF
--- a/collection-scripts/gather_ceph_pod_logs
+++ b/collection-scripts/gather_ceph_pod_logs
@@ -5,9 +5,9 @@
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 namespace=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
-storageClusterPresent=$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
-externalStorageClusterPresent=$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.spec.externalStorage.enable}}{{"\n"}}{{end}}')
-reconcileStrategy=$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
+storageClusterPresent=$(oc get storageclusters.ocs.openshift.io -n "${namespace}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+externalStorageClusterPresent=$(oc get storageclusters.ocs.openshift.io -n "${namespace}" -o go-template='{{range .items}}{{.spec.externalStorage.enable}}{{"\n"}}{{end}}')
+reconcileStrategy=$(oc get storageclusters.ocs.openshift.io -n "${namespace}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
 
 if [ "${externalStorageClusterPresent}" = "true" ]; then
     dbglog "Collecting limited ceph logs since external cluster is present"

--- a/collection-scripts/gather_namespaced_resources
+++ b/collection-scripts/gather_namespaced_resources
@@ -5,7 +5,7 @@
 BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
 
 # Make a global variable for namespace
-INSTALL_NAMESPACES=$(oc get storagecluster -A --no-headers | awk '{print $1}')
+INSTALL_NAMESPACES=$(oc get storageclusters.ocs.openshift.io -A --no-headers | awk '{print $1}')
 PRODUCT_NAMESPACE=$(oc get managedFusionOffering -A --no-headers | awk '{print $1}')
 OPERATOR_NAMESPACE=$(oc get subscription -A --no-headers | awk '{print $1}' | grep odf-operator)
 MANAGED_FUSION_NAMESPACE=$(oc get secrets -A --no-headers | grep managed-fusion-agent-config | awk '{print $1}')
@@ -102,7 +102,7 @@ for INSTALL_NAMESPACE in $PRODUCT_NAMESPACE $INSTALL_NAMESPACES $MANAGED_FUSION_
           { oc describe ${command_desc} -n ${INSTALL_NAMESPACE}; } >>"${COMMAND_OUTPUT_FILE}"
      done
      # NOTE: This is a temporary fix for collecting the storagecluster as we are not able to collect the storagecluster using the inspect command
-     { oc get storageclusters -n "${INSTALL_NAMESPACE}" -o yaml; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/storagecluster.yaml" 2>&1
+     { oc get storageclusters.ocs.openshift.io -n "${INSTALL_NAMESPACE}" -o yaml; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/storagecluster.yaml" 2>&1
      { oc get storagesystem -n "${INSTALL_NAMESPACE}" -o yaml; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/storagesystem.yaml" 2>&1
      { oc get storageconsumer -n "${INSTALL_NAMESPACE}" -o yaml; } >"${BASE_COLLECTION_PATH}/namespaces/${INSTALL_NAMESPACE}/oc_output/storageconsumer.yaml" 2>&1
 done

--- a/collection-scripts/gather_noobaa_resources
+++ b/collection-scripts/gather_noobaa_resources
@@ -74,7 +74,7 @@ done
 # Add important notifications to a notifications.txt file at the root of the noobaa collection path
 UNMANAGED_NOOBAA_NOTIF="The noobaa deployed on this cluster is not managed by the storagecluster CR and will not react to configuration changes made to storagecluster CR"
 
-NOOBAA_RECONCILE_STRATEGY=$(oc -n "${ns}" get storagecluster -o jsonpath='{.items[0].spec.multiCloudGateway.reconcileStrategy}' 2>/dev/null)
+NOOBAA_RECONCILE_STRATEGY=$(oc -n "${ns}" get storageclusters.ocs.openshift.io -o jsonpath='{.items[0].spec.multiCloudGateway.reconcileStrategy}' 2>/dev/null)
 if [ "${NOOBAA_RECONCILE_STRATEGY}" = "ignore" ] || [ "${NOOBAA_RECONCILE_STRATEGY}" = "standalone" ]; then
     if [ "$(oc -n "${ns}" get noobaa -o name 2>/dev/null)" ]; then
         echo "- ${UNMANAGED_NOOBAA_NOTIF}" >>"${NOOBAA_COLLLECTION_PATH}/notifications.txt"

--- a/collection-scripts/post-uninstall.sh
+++ b/collection-scripts/post-uninstall.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 namespace=$(oc get deploy --all-namespaces -o go-template --template='{{range .items}}{{if .metadata.labels}}{{printf "%s %v" .metadata.namespace (index .metadata.labels "olm.owner")}} {{printf "\n"}}{{end}}{{end}}' | grep ocs-operator | awk '{print $1}' | uniq)
-reconcileStrategy=$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
+reconcileStrategy=$(oc get storageclusters.ocs.openshift.io -n "${namespace}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
 
-if [ -n "$(oc get storagecluster -n "${namespace}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')" ] && [ "${reconcileStrategy}" != "standalone" ]; then
+if [ -n "$(oc get storageclusters.ocs.openshift.io -n "${namespace}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')" ] && [ "${reconcileStrategy}" != "standalone" ]; then
     oc delete -f pod_helper.yaml
 fi
 

--- a/collection-scripts/pre-install.sh
+++ b/collection-scripts/pre-install.sh
@@ -23,9 +23,9 @@ apply_helper_pod() {
 nodes=$(oc get nodes --no-headers | awk '/\yworker\y/{print $1}')
 
 # storing storagecluster name
-storageClusterPresent=$(oc get storagecluster -n "${ns}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+storageClusterPresent=$(oc get storageclusters.ocs.openshift.io -n "${ns}" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
 # checking for mcg standalone cluster
-reconcileStrategy=$(oc get storagecluster -n "${ns}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
+reconcileStrategy=$(oc get storageclusters.ocs.openshift.io -n "${ns}" -o go-template='{{range .items}}{{.spec.multiCloudGateway.reconcileStrategy}}{{"\n"}}{{end}}')
 deploy() {
     operatorImage=$(oc get pods -l app=rook-ceph-operator -n "${ns}" -o jsonpath="{range .items[*]}{@.spec.containers[0].image}+{end}" | tr "+" "\n" | head -n1)
     if [ -z "${storageClusterPresent}" ]; then


### PR DESCRIPTION
use ocs-storagecluster-ocs.openshift.io to collect ocs-storagecluster resources instead of ocs-storagecluster as in portworx we dont have ocs-storagecluster resource due to which must-gather fails to collect the ceph resources.

(cherry picked from commit 17207f38408a87a4b113086059743c1f75de385d)