### PR TITLE
Bootstrap scale must-gather conditionally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM registry.ci.openshift.org/ocp/4.20:cli
 
+# Allow CNSA must-gather image to be specified at the build time
+ARG CNSA_MG_IMAGE="icr.io/cpopen/ibm-spectrum-scale-must-gather:v6.0.1.0"
+ENV CNSA_MG_IMAGE="${CNSA_MG_IMAGE}"
+
 WORKDIR /usr/bin
 COPY collection-scripts .
 

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -12,6 +12,7 @@ clusterscoped=false
 help=false
 default=true
 minimal=false
+cnsa=false
 
 # Store PIDs of all the subprocesses
 pids=()
@@ -63,6 +64,11 @@ while [[ $# -gt 0 ]]; do
         default=false
         shift
         ;;
+    -cn | --cnsa)
+        cnsa=true
+        default=false
+        shift
+        ;;
     -h | --help)
         help=true
         default=false
@@ -99,6 +105,7 @@ Options:
   -cl, --ceph-logs          Collect ceph daemon, kernel, journal logs and crash reports
   -ns, --namespaced         Collect namespaced resources
   -cs, --clusterscoped      Collect clusterscoped resources
+  -cn, --cnsa               Collect must-gather for CNSA
   -m,  --minimal            Collect storagecluster, cephcluster CRDs and operator CSVs
   -h,  --help               Print this help message
 
@@ -207,6 +214,12 @@ fi
 if [ "$minimal" == true ]; then
     echo "Collect minimal resource files..."
     gather_minimal_resources ${BASE_COLLECTION_PATH} &
+    pids+=($!)
+fi
+
+if [ "$cnsa" == true ]; then
+    echo "Running CNSA must-gather..."
+    gather_cnsa &
     pids+=($!)
 fi
 

--- a/collection-scripts/gather_cnsa
+++ b/collection-scripts/gather_cnsa
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Expect base collection path as an exported variable
+# If it is not defined, use PWD instead
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"$(pwd)"}
+CNSA_COLLECTION_PATH="${BASE_COLLECTION_PATH}/cnsa"
+
+# The image to use for CNSA (can be overridden via build arg in Dockerfile)
+# If not present, the default value is set below.
+# Must-gather when running from its image will ALWAYS have this value set.
+CNSA_MG_IMAGE="${CNSA_MG_IMAGE:-"icr.io/cpopen/ibm-spectrum-scale-must-gather:v6.0.1.0"}"
+
+# Only continue if scale CRDs are present in the cluster
+if ! oc get clusters.scale.spectrum.ibm.com ibm-spectrum-scale >/dev/null 2>&1; then
+    echo "Scale cluster CRDs not detected in the cluster, exiting.."
+    exit 1
+fi
+
+# Make the directory
+mkdir -p "$CNSA_COLLECTION_PATH"
+
+# Simply run the MG and capture output at BASE_COLLECTION_PATH + CNSA
+oc adm must-gather \
+    --image="${CNSA_MG_IMAGE}" \
+    --dest-dir "$CNSA_COLLECTION_PATH"

--- a/collection-scripts/gather_main
+++ b/collection-scripts/gather_main
@@ -24,6 +24,9 @@ procids+=($!)
 gather_odf_client &
 procids+=($!)
 
+gather_cnsa &
+procids+=($!)
+
 # Check if procid array has any values, if so, wait for them to finish
 if [ ${#procids[@]} -ne 0 ]; then
     echo "Waiting on collection scripts to finish."


### PR DESCRIPTION
This patch does the following:
- Bootstraps scale must-gather if CRDs are detected in normal operating
  mode
- Add a new flag `-cn` or `--cnsa` to run just the CNSA must-gather.

The must-gather image to be used is defined inside `gather_cnsa` by
`CNSA_MG_IMAGE`. It would require updates if CNSA MG is to be updated.

The above can be specified/updated as a docker build arg and is consumed by
the script from ENV (injected at build time).