### PR TITLE
[main] Bump go (stdlib: net/http) from 1.20 to 1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/red-hat-storage/odf-must-gather
 
-go 1.20
+go 1.21.9
 
 require github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.20` → `1.21.9` (in `go.mod`)
